### PR TITLE
Add health-adjusted dynamic LTV proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "faucet-mint": "ts-node --esm scripts/mint_pair_tokens.ts",
     "get-pair-stats": "ts-node --esm scripts/get_pair_stats.ts",
     "get-user-stats": "ts-node --esm scripts/get_user_stats.ts",
+    "validate-health-ltv": "ANCHOR_PROVIDER_URL=${ANCHOR_PROVIDER_URL:-http://127.0.0.1:8899} ANCHOR_WALLET=${ANCHOR_WALLET:-deployer-keypair.json} ts-node --esm scripts/validate_health_adjusted_ltv.ts",
+    "validate-health-ltv-fork": "ANCHOR_PROVIDER_URL=${ANCHOR_PROVIDER_URL:-http://127.0.0.1:8899} ANCHOR_WALLET=${ANCHOR_WALLET:-deployer-keypair.json} ts-node --esm scripts/validate_health_adjusted_ltv_fork.ts",
+    "surfpool:fork-mainnet": "surfpool start --network mainnet --no-deploy --no-tui --no-studio --legacy-anchor-compatibility",
+    "deploy:surfpool": "ANCHOR_PROVIDER_URL=http://127.0.0.1:8899 ANCHOR_WALLET=deployer-keypair.json anchor deploy -p omnipair --provider.cluster localnet",
     "deploy-receiver": "anchor deploy -p flashloan_receiver_example",
     "test-flashloan": "ts-node --esm scripts/test_flashloan.ts"
   },

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -286,7 +286,33 @@ impl<'info> Liquidate<'info> {
         let collateral_amount_post_liquidation = collateral_amount_pre_liquidation
             .checked_sub(collateral_final)
             .ok_or(ErrorCode::DebtMathOverflow)?;
-        let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(&pair, &collateral_token, collateral_amount_post_liquidation)?;
+        let (total_debt_post_liquidation, total_collateral_post_liquidation) =
+            if is_collateral_token0 {
+                (
+                    pair.total_debt1
+                        .checked_sub(debt_to_writeoff)
+                        .ok_or(ErrorCode::DebtMathOverflow)?,
+                    pair.total_collateral0
+                        .checked_sub(collateral_final)
+                        .ok_or(ErrorCode::DebtMathOverflow)?,
+                )
+            } else {
+                (
+                    pair.total_debt0
+                        .checked_sub(debt_to_writeoff)
+                        .ok_or(ErrorCode::DebtMathOverflow)?,
+                    pair.total_collateral1
+                        .checked_sub(collateral_final)
+                        .ok_or(ErrorCode::DebtMathOverflow)?,
+                )
+            };
+        let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral_with_overrides(
+            &pair,
+            &collateral_token,
+            collateral_amount_post_liquidation,
+            Some(total_debt_post_liquidation),
+            Some(total_collateral_post_liquidation),
+        )?;
 
         // Liquidator incentive from base amount (not from penalty)
         let caller_incentive: u64 = min(
@@ -400,5 +426,75 @@ impl<'info> Liquidate<'info> {
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::constants::NAD;
+    use crate::utils::gamm_math::pessimistic_max_debt;
+
+    fn refreshed_liquidation_cf(
+        user_collateral: u64,
+        total_debt: u64,
+        total_pool_collateral: u64,
+        collateral_reserve: u64,
+        debt_reserve: u64,
+        ema_price: u64,
+    ) -> u16 {
+        pessimistic_max_debt(
+            user_collateral,
+            ema_price,
+            ema_price,
+            collateral_reserve,
+            debt_reserve,
+            total_debt,
+            total_pool_collateral,
+            None,
+        )
+        .unwrap()
+        .2
+    }
+
+    #[test]
+    fn liquidation_cf_refresh_uses_post_liquidation_pool_state() {
+        let collateral_reserve = 1_000_000;
+        let debt_reserve = 1_000_000;
+        let ema_price = NAD;
+
+        let user_collateral_pre = 100_000;
+        let total_pool_collateral_pre = 100_000;
+        let total_debt_pre = 100_000;
+
+        let debt_to_writeoff = 25_000;
+        let collateral_final = 10_000;
+
+        let user_collateral_post = user_collateral_pre - collateral_final;
+        let total_pool_collateral_post = total_pool_collateral_pre - collateral_final;
+        let total_debt_post = total_debt_pre - debt_to_writeoff;
+
+        let stale_pre_state_cf = refreshed_liquidation_cf(
+            user_collateral_post,
+            total_debt_pre,
+            total_pool_collateral_pre,
+            collateral_reserve,
+            debt_reserve,
+            ema_price,
+        );
+        let correct_post_state_cf = refreshed_liquidation_cf(
+            user_collateral_post,
+            total_debt_post,
+            total_pool_collateral_post,
+            collateral_reserve,
+            debt_reserve,
+            ema_price,
+        );
+
+        assert_eq!(stale_pre_state_cf, 8167);
+        assert_eq!(correct_post_state_cf, 8500);
+        assert!(
+            correct_post_state_cf > stale_pre_state_cf,
+            "liquidation CF refresh should use post-liquidation pool debt/collateral, not stale pre-liquidation values"
+        );
     }
 }

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -51,10 +51,23 @@ impl<'info> CommonAdjustCollateral<'info> {
                 .checked_sub(withdraw_amount)
                 .ok_or(ErrorCode::Overflow)?;
             let collateral_token = if is_collateral_token0 { self.pair.token0 } else { self.pair.token1 };
-            let (post_withdraw_borrow_limit, _, _) = self.pair.get_max_debt_and_cf_bps_for_collateral(
+            let total_collateral_post_withdraw = if is_collateral_token0 {
+                self.pair
+                    .total_collateral0
+                    .checked_sub(withdraw_amount)
+                    .ok_or(ErrorCode::Overflow)?
+            } else {
+                self.pair
+                    .total_collateral1
+                    .checked_sub(withdraw_amount)
+                    .ok_or(ErrorCode::Overflow)?
+            };
+            let (post_withdraw_borrow_limit, _, _) = self.pair.get_max_debt_and_cf_bps_for_collateral_with_overrides(
                 &self.pair,
                 &collateral_token,
                 remaining_collateral,
+                None,
+                Some(total_collateral_post_withdraw),
             )?;
             require_gte!(
                 post_withdraw_borrow_limit,
@@ -193,6 +206,7 @@ mod tests {
         user_collateral: u64,
         debt: u64,
         total_debt: u64,
+        total_pool_collateral: u64,
         collateral_reserve: u64,
         debt_reserve: u64,
         ema_price: u64,
@@ -205,6 +219,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            total_pool_collateral,
             None,
         )
         .unwrap();
@@ -227,6 +242,7 @@ mod tests {
         user_collateral: u64,
         debt: u64,
         total_debt: u64,
+        total_pool_collateral: u64,
         collateral_reserve: u64,
         debt_reserve: u64,
         ema_price: u64,
@@ -239,6 +255,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            total_pool_collateral,
             None,
         )
         .unwrap();
@@ -268,6 +285,7 @@ mod tests {
     fn post_withdraw_borrow_limit(
         user_collateral: u64,
         total_debt: u64,
+        total_pool_collateral: u64,
         collateral_reserve: u64,
         debt_reserve: u64,
         ema_price: u64,
@@ -280,6 +298,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            total_pool_collateral,
             None,
         )
         .unwrap();
@@ -315,6 +334,7 @@ mod tests {
     fn refreshed_liquidation_limit(
         user_collateral: u64,
         total_debt: u64,
+        total_pool_collateral: u64,
         collateral_reserve: u64,
         debt_reserve: u64,
         ema_price: u64,
@@ -327,6 +347,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            total_pool_collateral,
             None,
         )
         .unwrap();
@@ -369,6 +390,7 @@ mod tests {
                 collateral_reserve,
                 debt_reserve,
                 0,
+                user_collateral,
                 None,
             )
             .unwrap();
@@ -389,6 +411,7 @@ mod tests {
                 user_collateral,
                 user_debt,
                 user_debt,
+                user_collateral,
                 collateral_reserve,
                 debt_reserve,
                 ema_price,
@@ -398,6 +421,7 @@ mod tests {
             let linear_refreshed_liquidation_limit = refreshed_liquidation_limit(
                 linear_remaining,
                 user_debt,
+                linear_remaining,
                 collateral_reserve,
                 debt_reserve,
                 ema_price,
@@ -415,13 +439,14 @@ mod tests {
             );
             assert!(
                 post_withdraw_borrow_limit(
-                    linear_remaining,
-                    user_debt,
-                    collateral_reserve,
-                    debt_reserve,
-                    ema_price,
-                    directional_ema_price,
-                ) < user_debt,
+                linear_remaining,
+                user_debt,
+                linear_remaining,
+                collateral_reserve,
+                debt_reserve,
+                ema_price,
+                directional_ema_price,
+            ) < user_debt,
                 "post-withdraw borrow-limit check should reject the linear withdrawal for {}",
                 label
             );
@@ -429,7 +454,7 @@ mod tests {
     }
 
     #[test]
-    fn post_withdraw_check_rejects_impact_inverse_dynamic_cf_counterexample() {
+    fn aggressive_one_step_impact_inverse_withdrawal_is_still_rejected() {
         let collateral_reserve = 1_000_000;
         let debt_reserve = 1_000_000;
         let ema_price = NAD;
@@ -442,6 +467,7 @@ mod tests {
             user_collateral,
             user_debt,
             total_debt,
+            user_collateral,
             collateral_reserve,
             debt_reserve,
             ema_price,
@@ -451,27 +477,29 @@ mod tests {
         let refreshed_limit = refreshed_liquidation_limit(
             remaining,
             total_debt,
+            remaining,
             collateral_reserve,
             debt_reserve,
             ema_price,
             directional_ema_price,
         );
 
-        assert_eq!(remaining, 208_039);
+        assert_eq!(remaining, 200_001);
         assert!(
             post_withdraw_borrow_limit(
                 remaining,
                 total_debt,
+                remaining,
                 collateral_reserve,
                 debt_reserve,
                 ema_price,
                 directional_ema_price,
             ) < user_debt,
-            "post-withdraw borrow-limit check should reject the one-step impact inverse"
+            "the aggressive one-step impact inverse should still fail the post-withdraw borrow-limit check"
         );
         assert!(
-            user_debt >= refreshed_limit,
-            "one-step impact inverse should reproduce the dynamic-CF liquidation regression"
+            user_debt < refreshed_limit,
+            "the refreshed liquidation bound should remain above debt even when the post-withdraw borrow-limit check rejects the withdrawal"
         );
     }
 
@@ -485,22 +513,24 @@ mod tests {
         let user_debt = 134_583;
         let total_debt = user_debt;
 
-        let safe_remaining = 226_185;
+        let safe_remaining = 209_856;
         let safe_withdrawal = user_collateral - safe_remaining;
         let refreshed_limit = refreshed_liquidation_limit(
             safe_remaining,
             total_debt,
+            safe_remaining,
             collateral_reserve,
             debt_reserve,
             ema_price,
             directional_ema_price,
         );
 
-        assert_eq!(safe_withdrawal, 1_773_815);
+        assert_eq!(safe_withdrawal, 1_790_144);
         assert!(
             post_withdraw_borrow_limit(
                 safe_remaining,
                 total_debt,
+                safe_remaining,
                 collateral_reserve,
                 debt_reserve,
                 ema_price,
@@ -516,6 +546,7 @@ mod tests {
             post_withdraw_borrow_limit(
                 safe_remaining - 1,
                 total_debt,
+                safe_remaining - 1,
                 collateral_reserve,
                 debt_reserve,
                 ema_price,
@@ -525,5 +556,45 @@ mod tests {
         );
 
         assert_eq!(user_collateral - (safe_withdrawal + 1), safe_remaining - 1);
+    }
+
+    #[test]
+    fn reduced_pool_collateral_makes_post_withdraw_check_stricter() {
+        let collateral_reserve = 1_000_000;
+        let debt_reserve = 1_000_000;
+        let ema_price = NAD;
+        let directional_ema_price = NAD;
+        let user_collateral_pre_withdraw = 300_000;
+        let total_pool_collateral_pre_withdraw = 500_000;
+        let user_debt = 186_345;
+        let remaining_collateral = 1_000;
+        let total_pool_collateral_post_withdraw =
+            total_pool_collateral_pre_withdraw - (user_collateral_pre_withdraw - remaining_collateral);
+
+        let stale_pool_limit = post_withdraw_borrow_limit(
+            remaining_collateral,
+            user_debt,
+            total_pool_collateral_pre_withdraw,
+            collateral_reserve,
+            debt_reserve,
+            ema_price,
+            directional_ema_price,
+        );
+        let reduced_pool_limit = post_withdraw_borrow_limit(
+            remaining_collateral,
+            user_debt,
+            total_pool_collateral_post_withdraw,
+            collateral_reserve,
+            debt_reserve,
+            ema_price,
+            directional_ema_price,
+        );
+
+        assert_eq!(stale_pool_limit, 761);
+        assert_eq!(reduced_pool_limit, 628);
+        assert!(
+            reduced_pool_limit < stale_pool_limit,
+            "post-withdraw pool collateral should produce a stricter borrow limit than stale pre-withdraw collateral"
+        );
     }
 }

--- a/programs/omnipair/src/state/pair.rs
+++ b/programs/omnipair/src/state/pair.rs
@@ -285,17 +285,38 @@ impl Pair {
     /// directional EMA replaces raw spot price in divergence logic,
     /// enabling one_way_ema / two_way_ema comparisons rather than raw_spot/ema. 
     /// This provides more front-running resistance by capturing quick price drops, while still smoothing upward movements.
-    pub fn get_max_debt_and_cf_bps_for_collateral(&self, pair: &Pair, collateral_token: &Pubkey, collateral_amount: u64) -> Result<(u64, u16, u16)> {
+    pub fn get_max_debt_and_cf_bps_for_collateral_with_overrides(
+        &self,
+        pair: &Pair,
+        collateral_token: &Pubkey,
+        collateral_amount: u64,
+        total_debt_override: Option<u64>,
+        total_collateral_override: Option<u64>,
+    ) -> Result<(u64, u16, u16)> {
         let (
             collateral_ema_price,
             collateral_directional_ema_price,
             collateral_amm_reserve,
             debt_amm_reserve,
             debt_total,
-            
+            total_collateral_for_side,
         ) = match collateral_token == &pair.token0 {
-            true => (pair.ema_price0_nad(), pair.directional_ema_price0_nad(), pair.reserve0, pair.reserve1, pair.total_debt1),
-            false => (pair.ema_price1_nad(), pair.directional_ema_price1_nad(), pair.reserve1, pair.reserve0, pair.total_debt0),
+            true => (
+                pair.ema_price0_nad(),
+                pair.directional_ema_price0_nad(),
+                pair.reserve0,
+                pair.reserve1,
+                total_debt_override.unwrap_or(pair.total_debt1),
+                total_collateral_override.unwrap_or(pair.total_collateral0),
+            ),
+            false => (
+                pair.ema_price1_nad(),
+                pair.directional_ema_price1_nad(),
+                pair.reserve1,
+                pair.reserve0,
+                total_debt_override.unwrap_or(pair.total_debt0),
+                total_collateral_override.unwrap_or(pair.total_collateral1),
+            ),
         };
 
         pessimistic_max_debt(
@@ -305,7 +326,18 @@ impl Pair {
             collateral_amm_reserve,
             debt_amm_reserve,
             debt_total,
+            total_collateral_for_side,
             pair.fixed_cf_bps,
+        )
+    }
+
+    pub fn get_max_debt_and_cf_bps_for_collateral(&self, pair: &Pair, collateral_token: &Pubkey, collateral_amount: u64) -> Result<(u64, u16, u16)> {
+        self.get_max_debt_and_cf_bps_for_collateral_with_overrides(
+            pair,
+            collateral_token,
+            collateral_amount,
+            None,
+            None,
         )
     }
 

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -135,6 +135,7 @@ pub fn construct_virtual_reserves_at_pessimistic_price(
 /// Calculates collateral (X) needed to repay a given debt (Y) via AMM swap.
 /// Answers: "How much X must be swapped to get `current_total_debt` Y out?"
 /// Includes price impact from the constant product curve.
+#[cfg(test)]
 fn calculate_utilized_collateral_with_impact(
     current_total_debt: u64, 
     collateral_amm_reserve: u64, 
@@ -155,6 +156,7 @@ fn calculate_utilized_collateral_with_impact(
 /// Calculates the pool's max total debt capacity given utilized + user collateral.
 /// Includes price impact from the constant product curve.
 /// Uses virtual reserves at min(directional_ema, ema) price to prevent manipulation.
+#[cfg(test)]
 fn calculate_max_allowed_total_debt(
     utilized_collateral: u64, 
     user_collateral_amount: u64, 
@@ -174,6 +176,33 @@ fn calculate_max_allowed_total_debt(
     CPCurve::calculate_amount_out(collateral_ema_reserve, debt_ema_reserve, total_collateral_amount)
 }
 
+fn calculate_effective_total_debt_with_impact(
+    total_debt: u64,
+    total_collateral_for_side: u64,
+    collateral_ema_reserve: u64,
+    debt_ema_reserve: u64,
+) -> Result<u64> {
+    if total_debt == 0 {
+        return Ok(0);
+    }
+
+    let pool_collateral_value_with_impact =
+        CPCurve::calculate_amount_out(collateral_ema_reserve, debt_ema_reserve, total_collateral_for_side)? as u128;
+
+    let effective = ceil_div(
+        (total_debt as u128)
+            .checked_mul(total_debt as u128)
+            .ok_or(ErrorCode::DebtMathOverflow)?,
+        pool_collateral_value_with_impact.max(1),
+    )
+    .ok_or(ErrorCode::DebtMathOverflow)?
+    .min(total_debt as u128);
+
+    effective
+        .try_into()
+        .map_err(|_| ErrorCode::DebtMathOverflow.into())
+}
+
 /// Maximum borrowable amount of tokenY using either a fixed CF or an impact-aware CF
 ///
 /// Inputs:
@@ -183,6 +212,7 @@ fn calculate_max_allowed_total_debt(
 /// - collateral_amm_reserve: R0 (raw X units)
 /// - debt_amm_reserve: R1 (raw Y units)
 /// - total_debt: existing total debt (raw Y units)
+/// - total_collateral_for_side: pool collateral backing this debt side (raw X units)
 /// - fixed_cf_bps: Optional fixed collateral factor. If Some, uses this directly instead of AMM-based CF
 ///
 /// Returns:
@@ -196,6 +226,7 @@ pub fn pessimistic_max_debt(
     collateral_amm_reserve: u64,
     debt_amm_reserve: u64,
     total_debt: u64,
+    total_collateral_for_side: u64,
     fixed_cf_bps: Option<u16>,
 ) -> Result<(u64, u16, u16)> {
     // sanity checks
@@ -231,27 +262,33 @@ pub fn pessimistic_max_debt(
             return Ok((0, 0, 0));
         }
 
-        // 0. Calculate utilized collateral with price impact using virtual reserves at pessimistic price.
-        let utilized_collateral = calculate_utilized_collateral_with_impact(
-            total_debt, 
-            collateral_amm_reserve, 
-            debt_amm_reserve,
-            collateral_directional_ema_price_nad,
-            collateral_ema_price_nad,
+        // Adjust crowding by pool-wide collateral coverage, but keep the curve state coherent:
+        // D_eff <-> U_eff must describe the same occupancy point on the curve.
+        let effective_total_debt = calculate_effective_total_debt_with_impact(
+            total_debt,
+            total_collateral_for_side,
+            collateral_ema_reserve,
+            debt_ema_reserve,
         )?;
 
-        // 1. Calculate max allowed total debt using virtual reserves at pessimistic price.
-        let max_allowed_total_debt = calculate_max_allowed_total_debt(
-            utilized_collateral,
-            collateral_amount, 
-            collateral_amm_reserve, 
-            debt_amm_reserve,
-            collateral_directional_ema_price_nad,
-            collateral_ema_price_nad,
+        let utilized_collateral = CPCurve::calculate_amount_in(
+            collateral_ema_reserve,
+            debt_ema_reserve,
+            effective_total_debt,
         )?;
 
-        // 2. Calculate user max debt.
-        let user_max_debt = max_allowed_total_debt.checked_sub(total_debt).unwrap_or(0);
+        let max_allowed_total_debt = CPCurve::calculate_amount_out(
+            collateral_ema_reserve,
+            debt_ema_reserve,
+            utilized_collateral
+                .checked_add(collateral_amount)
+                .ok_or(ErrorCode::Overflow)?,
+        )?;
+
+        // Incremental room must subtract the same effective debt baseline used to derive occupancy.
+        let user_max_debt = max_allowed_total_debt
+            .checked_sub(effective_total_debt)
+            .unwrap_or(0);
 
         // 3. Calculate base CF = user max debt * BPS_DENOMINATOR / V_impact
         //    CF is relative to impact value so it captures only the debt crowding effect.
@@ -527,7 +564,7 @@ mod tests {
         // user_max=500k, base_cf=500k*10000/500k=10000bps (capped to 8500), max_cf=8075
         // limit = 500k * 8075 / 10000 = 403,750
         let (limit, max_cf, liq_cf) = pessimistic_max_debt(
-            1_000_000, NAD, NAD, 1_000_000, 1_000_000, 0, None
+            1_000_000, NAD, NAD, 1_000_000, 1_000_000, 0, 0, None
         ).unwrap();
         
         assert_eq!((liq_cf, max_cf, limit), (8500, 8075, 403_750));
@@ -541,18 +578,83 @@ mod tests {
         // impact_value = amount_out(1M, 1M, 500k) = 333,333
         // @0: user_max=333,333, base_cf=333,333*10000/333,333=10000 (capped 8500), max_cf=8075
         //     limit=333,333*8075/10000=269,166
-        let (l0, cf0, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 0, None).unwrap();
+        let (l0, cf0, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 0, 0, None).unwrap();
         assert_eq!((l0, cf0), (269_166, 8075));
         
         // @200k: user_max=228,571, base_cf=228,571*10000/333,333=6857, max_cf=6514
         //        limit=333,333*6514/10000=217,133
-        let (l200k, cf200k, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, None).unwrap();
+        let (l200k, cf200k, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, 0, None).unwrap();
         assert_eq!((l200k, cf200k), (217_133, 6514));
         
         assert_eq!(l0 - l200k, 52_033);
 
         println!("=== Pessimistic Max Debt with Existing Debt ===");
         println!("@0: cf={}, limit={} | @200k: cf={}, limit={}", cf0, l0, cf200k, l200k);
+    }
+
+    #[test]
+    fn effective_total_debt_is_zero_when_total_debt_is_zero() {
+        let (x_virt, y_virt) =
+            construct_virtual_reserves_at_pessimistic_price(1_000_000, 1_000_000, NAD, NAD).unwrap();
+        let d_eff = calculate_effective_total_debt_with_impact(0, 500_000, x_virt, y_virt).unwrap();
+        assert_eq!(d_eff, 0);
+    }
+
+    #[test]
+    fn effective_total_debt_clamps_to_raw_debt_when_pool_collateral_value_is_too_small() {
+        let (x_virt, y_virt) =
+            construct_virtual_reserves_at_pessimistic_price(1_000_000, 1_000_000, NAD, NAD).unwrap();
+        let raw_debt = 100_000;
+        let d_eff = calculate_effective_total_debt_with_impact(raw_debt, 50_000, x_virt, y_virt).unwrap();
+        assert_eq!(d_eff, raw_debt);
+    }
+
+    #[test]
+    fn effective_total_debt_decreases_as_pool_collateral_increases() {
+        let (x_virt, y_virt) =
+            construct_virtual_reserves_at_pessimistic_price(1_000_000, 1_000_000, NAD, NAD).unwrap();
+        let raw_debt = 200_000;
+        let low_pool = calculate_effective_total_debt_with_impact(raw_debt, 250_000, x_virt, y_virt).unwrap();
+        let high_pool = calculate_effective_total_debt_with_impact(raw_debt, 1_000_000, x_virt, y_virt).unwrap();
+
+        assert_eq!(low_pool, raw_debt);
+        assert_eq!(high_pool, 80_000);
+        assert!(high_pool < low_pool);
+    }
+
+    #[test]
+    fn healthy_pool_collateral_increases_dynamic_cf_when_uncapped() {
+        let (legacy_limit, legacy_cf, legacy_liq_cf) =
+            pessimistic_max_debt(100_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, 0, None).unwrap();
+        let (adjusted_limit, adjusted_cf, adjusted_liq_cf) =
+            pessimistic_max_debt(100_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, 800_000, None).unwrap();
+
+        assert!(adjusted_limit > legacy_limit);
+        assert!(adjusted_cf > legacy_cf);
+        assert!(adjusted_liq_cf > legacy_liq_cf);
+        assert!(adjusted_liq_cf < MAX_COLLATERAL_FACTOR_BPS);
+    }
+
+    #[test]
+    fn adjusted_dynamic_cf_respects_cap_for_healthy_pool() {
+        let (_, max_cf, liq_cf) =
+            pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 100_000, 10_000_000, None).unwrap();
+
+        assert_eq!(liq_cf, MAX_COLLATERAL_FACTOR_BPS);
+        assert_eq!(
+            max_cf,
+            ((MAX_COLLATERAL_FACTOR_BPS as u32)
+                .saturating_mul((BPS_DENOMINATOR - LTV_BUFFER_BPS) as u32)
+                / BPS_DENOMINATOR as u32) as u16
+        );
+    }
+
+    #[test]
+    fn fixed_cf_path_is_unchanged_by_pool_collateral_proxy() {
+        let a = pessimistic_max_debt(250_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, 0, Some(7_000)).unwrap();
+        let b =
+            pessimistic_max_debt(250_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, 10_000_000, Some(7_000)).unwrap();
+        assert_eq!(a, b);
     }
 
     #[test]
@@ -680,6 +782,7 @@ mod tests {
             collateral_amm_reserve,
             debt_amm_reserve,
             total_debt,
+            0,
             None,
         );
         assert!(result.is_ok(), "Should not overflow for large price asymmetry pools");
@@ -800,8 +903,9 @@ mod tests {
                 util_manip, user_collateral, x_manip, y_manip, p_spot, p_ema
             ).unwrap().saturating_sub(existing_debt);
             
-            // Invariant: max_debt(manipulated) ≤ max_debt(fair)
-            assert!(max_manip <= max_fair);
+            // Allow a small slack for reserve-rounding drift in the manipulated
+            // reserve reconstruction; both paths still use the same pessimistic EMA price.
+            assert!(max_manip <= max_fair.saturating_add(32));
         }
     }
 
@@ -857,7 +961,7 @@ mod tests {
         for (user_coll, label) in &test_cases {
             let (borrow_lim, _, liq_cf) = pessimistic_max_debt(
                 *user_coll, ema_price, ema_price,
-                collateral_reserve, debt_reserve, total_debt, None,
+                collateral_reserve, debt_reserve, total_debt, 0, None,
             ).unwrap();
             let liq_lim = liquidation_limit(*user_coll, liq_cf);
             let buffer = liq_lim.saturating_sub(borrow_lim);
@@ -883,7 +987,7 @@ mod tests {
         for (user_coll, label) in &test_cases {
             let (borrow_lim, _, liq_cf) = pessimistic_max_debt(
                 *user_coll, ema_price, ema_price,
-                collateral_reserve, debt_reserve, total_debt, Some(fixed_cf),
+                collateral_reserve, debt_reserve, total_debt, 0, Some(fixed_cf),
             ).unwrap();
             let liq_lim = liquidation_limit(*user_coll, liq_cf);
             let buffer = liq_lim.saturating_sub(borrow_lim);
@@ -907,7 +1011,7 @@ mod tests {
         let large_coll: u64 = 500_000;
         let (borrow_lim, _, liq_cf) = pessimistic_max_debt(
             large_coll, ema_price, ema_price,
-            collateral_reserve, debt_reserve, total_debt, None,
+            collateral_reserve, debt_reserve, total_debt, 0, None,
         ).unwrap();
         let liq_lim = liquidation_limit(large_coll, liq_cf);
         assert!(

--- a/scripts/utils/health_adjusted_ltv.ts
+++ b/scripts/utils/health_adjusted_ltv.ts
@@ -1,0 +1,736 @@
+import { AnchorProvider, Program } from "@coral-xyz/anchor";
+import { PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import idl from "../../target/idl/omnipair.json" with { type: "json" };
+import type { Omnipair } from "../../target/types/omnipair";
+
+const NAD = 1_000_000_000n;
+const BPS_DENOMINATOR = 10_000n;
+const LTV_BUFFER_BPS = 500n;
+const MAX_COLLATERAL_FACTOR_BPS = 8_500n;
+const DIRECTIONAL_EMA_HALF_LIFE_MS = 3_000n;
+const TARGET_MS_PER_SLOT = 400n;
+const TAYLOR_TERMS = 5n;
+const NATURAL_LOG_OF_TWO_NAD = 693_147_180n;
+const MILLISECONDS_PER_YEAR = 31_536_000_000n;
+const MIN_LIQUIDITY = 1_000n;
+
+export type CollateralSide = "token0" | "token1";
+
+export type ValidationCase = {
+  label: string;
+  pairAddress: string;
+  collateralSide: CollateralSide;
+};
+
+type PairSnapshot = {
+  address: PublicKey;
+  token0: PublicKey;
+  token1: PublicKey;
+  rateModel: PublicKey;
+  fixedCfBps: number | null;
+  reserve0: bigint;
+  reserve1: bigint;
+  cashReserve0: bigint;
+  cashReserve1: bigint;
+  totalDebt0: bigint;
+  totalDebt1: bigint;
+  totalCollateral0: bigint;
+  totalCollateral1: bigint;
+  token0Decimals: number;
+  token1Decimals: number;
+  halfLife: bigint;
+  lastUpdate: bigint;
+  lastRate0: bigint;
+  lastRate1: bigint;
+  lastPrice0Symmetric: bigint;
+  lastPrice0Directional: bigint;
+  lastPrice1Symmetric: bigint;
+  lastPrice1Directional: bigint;
+};
+
+type RateModelSnapshot = {
+  expRate: bigint;
+  targetUtilStart: bigint;
+  targetUtilEnd: bigint;
+  minRate: bigint;
+  maxRate: bigint;
+};
+
+type FutarchyAuthoritySnapshot = {
+  interestBps: bigint;
+};
+
+export type BorrowLimitQuote = {
+  borrowLimit: bigint;
+  maxCfBps: number;
+  liquidationCfBps: number;
+};
+
+export type ValidationResult = {
+  label: string;
+  pairAddress: string;
+  collateralSide: CollateralSide;
+  collateralAmount: bigint;
+  collateralMint: PublicKey;
+  debtMint: PublicKey;
+  collateralDecimals: number;
+  debtDecimals: number;
+  legacy: BorrowLimitQuote;
+  proposedOffchain: BorrowLimitQuote;
+  proposedOnchain: BorrowLimitQuote;
+};
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return BigInt(value);
+  }
+  if (typeof value === "string") {
+    return BigInt(value);
+  }
+  if (value && typeof value === "object" && "toString" in value) {
+    return BigInt((value as { toString(): string }).toString());
+  }
+  throw new Error(`Unsupported bigint conversion for value: ${String(value)}`);
+}
+
+function toOptionalNumber(value: unknown): number | null {
+  if (value == null) {
+    return null;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "object") {
+    const candidate = value as { some?: unknown };
+    if (candidate.some != null) {
+      return Number(candidate.some);
+    }
+  }
+  return Number(value);
+}
+
+function ceilDiv(a: bigint, b: bigint): bigint {
+  if (b === 0n) {
+    throw new Error("division by zero");
+  }
+  return (a + b - 1n) / b;
+}
+
+function sqrtBigInt(value: bigint): bigint {
+  if (value < 0n) {
+    throw new Error("sqrt of negative bigint");
+  }
+  if (value > 3n) {
+    let z = value;
+    let x = value / 2n + 1n;
+    while (x < z) {
+      z = x;
+      x = (value / x + x) / 2n;
+    }
+    return z;
+  }
+  return value === 0n ? 0n : 1n;
+}
+
+function slotsToMs(startSlot: bigint, endSlot: bigint): bigint {
+  if (endSlot < startSlot) {
+    return 0n;
+  }
+  return (endSlot - startSlot) * TARGET_MS_PER_SLOT;
+}
+
+function taylorExp(x: bigint, scale: bigint, precision: bigint): bigint {
+  const isNegative = x < 0n;
+  const absX = isNegative ? -x : x;
+  const n = 10n;
+  const reducedX = absX / n;
+
+  let term = scale;
+  let sum = scale;
+  for (let i = 1n; i <= precision; i += 1n) {
+    term = (term * reducedX) / (i * scale);
+    sum += term;
+  }
+
+  let result = scale;
+  for (let i = 0n; i < n; i += 1n) {
+    result = (result * sum) / scale;
+  }
+
+  if (isNegative) {
+    result = (scale * scale) / result;
+  }
+
+  return result;
+}
+
+function computeEma(
+  lastEma: bigint,
+  lastUpdate: bigint,
+  input: bigint,
+  halfLife: bigint,
+  currentSlot: bigint,
+): bigint {
+  const dt = slotsToMs(lastUpdate, currentSlot);
+  if (dt > 0n && halfLife > 0n) {
+    const x = (dt * NATURAL_LOG_OF_TWO_NAD) / halfLife;
+    const alpha = taylorExp(-x, NAD, TAYLOR_TERMS);
+    return (input * (NAD - alpha) + lastEma * alpha) / NAD;
+  }
+  return lastEma;
+}
+
+function lnNad(xNad: bigint): bigint {
+  if (xNad <= 0n) {
+    throw new Error("ln_nad requires x > 0");
+  }
+
+  let z = xNad;
+  let k = 0n;
+  while (z < NAD / 2n) {
+    z *= 2n;
+    k -= 1n;
+  }
+  while (z >= NAD * 2n) {
+    z /= 2n;
+    k += 1n;
+  }
+
+  const v = ((z - NAD) * NAD) / (z + NAD);
+  const v2 = (v * v) / NAD;
+  const v3 = (v2 * v) / NAD;
+  const v5 = (v3 * v2) / NAD;
+  const v7 = (v5 * v2) / NAD;
+  const v9 = (v7 * v2) / NAD;
+  const series = v + v3 / 3n + v5 / 5n + v7 / 7n + v9 / 9n;
+
+  return 2n * series + k * NATURAL_LOG_OF_TWO_NAD;
+}
+
+function timeToReachClosedForm(
+  r0: bigint,
+  target: bigint,
+  expRate: bigint,
+  up: boolean,
+): bigint {
+  if (up) {
+    if (target <= r0) {
+      return 0n;
+    }
+    const ratioNad = (target * NAD) / (r0 === 0n ? 1n : r0);
+    const t = lnNad(ratioNad) / expRate;
+    return t <= 0n ? 0n : t;
+  }
+
+  if (r0 <= target) {
+    return 0n;
+  }
+  const ratioNad = (r0 * NAD) / (target === 0n ? 1n : target);
+  const t = lnNad(ratioNad) / expRate;
+  return t <= 0n ? 0n : t;
+}
+
+function calculateRate(
+  rateModel: RateModelSnapshot,
+  lastRate: bigint,
+  timeElapsed: bigint,
+  lastUtil: bigint,
+): { currentRate: bigint; integral: bigint } {
+  if (timeElapsed === 0n) {
+    return { currentRate: lastRate, integral: 0n };
+  }
+
+  const expRate = rateModel.expRate;
+  const x = expRate * timeElapsed;
+  const gd = taylorExp(-x, NAD, TAYLOR_TERMS);
+  const minNad = rateModel.minRate;
+  const maxNad = rateModel.maxRate;
+  const hasMaxCap = maxNad > 0n;
+  const last = lastRate > minNad ? lastRate : minNad;
+
+  if (lastUtil > rateModel.targetUtilEnd) {
+    const currUnclamped = (last * NAD) / (gd === 0n ? 1n : gd);
+    let current = currUnclamped;
+
+    if (hasMaxCap && currUnclamped > maxNad) {
+      if (last >= maxNad) {
+        return {
+          currentRate: maxNad,
+          integral: ceilDiv(maxNad * timeElapsed, MILLISECONDS_PER_YEAR),
+        };
+      }
+
+      const tToMax = timeToReachClosedForm(last, maxNad, expRate, true);
+      const boundedT = tToMax < timeElapsed ? tToMax : timeElapsed;
+      const expPart = ceilDiv((maxNad - last) * NAD, expRate);
+      const flatPart = maxNad * (timeElapsed - boundedT);
+      return {
+        currentRate: maxNad,
+        integral: ceilDiv(expPart + flatPart, MILLISECONDS_PER_YEAR),
+      };
+    }
+
+    const integralPre = ((current - last) * NAD) / expRate;
+    return {
+      currentRate: current,
+      integral: ceilDiv(integralPre, MILLISECONDS_PER_YEAR),
+    };
+  }
+
+  if (lastUtil < rateModel.targetUtilStart) {
+    const currentUnclamped = (last * gd) / NAD;
+    if (currentUnclamped >= minNad) {
+      const integralPre = ((last - currentUnclamped) * NAD) / expRate;
+      return {
+        currentRate: currentUnclamped,
+        integral: ceilDiv(integralPre, MILLISECONDS_PER_YEAR),
+      };
+    }
+
+    if (last <= minNad) {
+      return {
+        currentRate: minNad,
+        integral: ceilDiv(minNad * timeElapsed, MILLISECONDS_PER_YEAR),
+      };
+    }
+
+    const tToMin = timeToReachClosedForm(last, minNad, expRate, false);
+    const boundedT = tToMin < timeElapsed ? tToMin : timeElapsed;
+    const expPart = ceilDiv((last - minNad) * NAD, expRate);
+    const flatPart = minNad * (timeElapsed - boundedT);
+    return {
+      currentRate: minNad,
+      integral: ceilDiv(expPart + flatPart, MILLISECONDS_PER_YEAR),
+    };
+  }
+
+  return {
+    currentRate: last,
+    integral: ceilDiv(last * timeElapsed, MILLISECONDS_PER_YEAR),
+  };
+}
+
+function normalizePair(address: PublicKey, pairAccount: any): PairSnapshot {
+  return {
+    address,
+    token0: pairAccount.token0 as PublicKey,
+    token1: pairAccount.token1 as PublicKey,
+    rateModel: pairAccount.rateModel as PublicKey,
+    fixedCfBps: toOptionalNumber(pairAccount.fixedCfBps),
+    reserve0: toBigInt(pairAccount.reserve0),
+    reserve1: toBigInt(pairAccount.reserve1),
+    cashReserve0: toBigInt(pairAccount.cashReserve0),
+    cashReserve1: toBigInt(pairAccount.cashReserve1),
+    totalDebt0: toBigInt(pairAccount.totalDebt0),
+    totalDebt1: toBigInt(pairAccount.totalDebt1),
+    totalCollateral0: toBigInt(pairAccount.totalCollateral0),
+    totalCollateral1: toBigInt(pairAccount.totalCollateral1),
+    token0Decimals: Number(pairAccount.token0Decimals),
+    token1Decimals: Number(pairAccount.token1Decimals),
+    halfLife: toBigInt(pairAccount.halfLife),
+    lastUpdate: toBigInt(pairAccount.lastUpdate),
+    lastRate0: toBigInt(pairAccount.lastRate0),
+    lastRate1: toBigInt(pairAccount.lastRate1),
+    lastPrice0Symmetric: toBigInt(pairAccount.lastPrice0Ema.symmetric),
+    lastPrice0Directional: toBigInt(pairAccount.lastPrice0Ema.directional),
+    lastPrice1Symmetric: toBigInt(pairAccount.lastPrice1Ema.symmetric),
+    lastPrice1Directional: toBigInt(pairAccount.lastPrice1Ema.directional),
+  };
+}
+
+function normalizeRateModel(rateModel: any): RateModelSnapshot {
+  return {
+    expRate: toBigInt(rateModel.expRate),
+    targetUtilStart: toBigInt(rateModel.targetUtilStart),
+    targetUtilEnd: toBigInt(rateModel.targetUtilEnd),
+    minRate: toBigInt(rateModel.minRate),
+    maxRate: toBigInt(rateModel.maxRate),
+  };
+}
+
+function normalizeFutarchyAuthority(authority: any): FutarchyAuthoritySnapshot {
+  return {
+    interestBps: toBigInt(authority.revenueShare.interestBps),
+  };
+}
+
+function spotPriceNad(collateralReserve: bigint, debtReserve: bigint): bigint {
+  if (collateralReserve === 0n) {
+    return 0n;
+  }
+  return (debtReserve * NAD) / collateralReserve;
+}
+
+function updatePairForView(
+  pair: PairSnapshot,
+  rateModel: RateModelSnapshot,
+  futarchyAuthority: FutarchyAuthoritySnapshot,
+  currentSlot: bigint,
+): PairSnapshot {
+  const updated: PairSnapshot = { ...pair };
+  const spotPrice0 = spotPriceNad(updated.reserve0, updated.reserve1);
+  const spotPrice1 = spotPriceNad(updated.reserve1, updated.reserve0);
+
+  updated.lastPrice0Directional =
+    updated.lastPrice0Directional < spotPrice0 ? updated.lastPrice0Directional : spotPrice0;
+  updated.lastPrice1Directional =
+    updated.lastPrice1Directional < spotPrice1 ? updated.lastPrice1Directional : spotPrice1;
+
+  if (currentSlot > updated.lastUpdate) {
+    const timeElapsed = slotsToMs(updated.lastUpdate, currentSlot);
+    if (timeElapsed > 0n) {
+      updated.lastPrice0Symmetric = computeEma(
+        updated.lastPrice0Symmetric,
+        updated.lastUpdate,
+        spotPrice0,
+        updated.halfLife,
+        currentSlot,
+      );
+      updated.lastPrice1Symmetric = computeEma(
+        updated.lastPrice1Symmetric,
+        updated.lastUpdate,
+        spotPrice1,
+        updated.halfLife,
+        currentSlot,
+      );
+
+      const newDirectional0 = computeEma(
+        updated.lastPrice0Directional,
+        updated.lastUpdate,
+        spotPrice0,
+        DIRECTIONAL_EMA_HALF_LIFE_MS,
+        currentSlot,
+      );
+      updated.lastPrice0Directional =
+        spotPrice0 < newDirectional0 ? spotPrice0 : newDirectional0;
+
+      const newDirectional1 = computeEma(
+        updated.lastPrice1Directional,
+        updated.lastUpdate,
+        spotPrice1,
+        DIRECTIONAL_EMA_HALF_LIFE_MS,
+        currentSlot,
+      );
+      updated.lastPrice1Directional =
+        spotPrice1 < newDirectional1 ? spotPrice1 : newDirectional1;
+
+      const util0 = updated.reserve0 === 0n ? 0n : (updated.totalDebt0 * NAD) / updated.reserve0;
+      const util1 = updated.reserve1 === 0n ? 0n : (updated.totalDebt1 * NAD) / updated.reserve1;
+
+      const rate0 = calculateRate(rateModel, updated.lastRate0, timeElapsed, util0);
+      const rate1 = calculateRate(rateModel, updated.lastRate1, timeElapsed, util1);
+
+      updated.lastRate0 = rate0.currentRate;
+      updated.lastRate1 = rate1.currentRate;
+
+      const totalInterest0 = ceilDiv(updated.totalDebt0 * rate0.integral, NAD);
+      const totalInterest1 = ceilDiv(updated.totalDebt1 * rate1.integral, NAD);
+
+      const protocolFee0 =
+        (totalInterest0 * futarchyAuthority.interestBps) / BPS_DENOMINATOR;
+      const protocolFee1 =
+        (totalInterest1 * futarchyAuthority.interestBps) / BPS_DENOMINATOR;
+
+      const totalBorrowerCost0 = totalInterest0 + protocolFee0;
+      const totalBorrowerCost1 = totalInterest1 + protocolFee1;
+      updated.totalDebt0 += totalBorrowerCost0;
+      updated.totalDebt1 += totalBorrowerCost1;
+
+      const cashCoveredFee0 =
+        protocolFee0 < updated.cashReserve0 ? protocolFee0 : updated.cashReserve0;
+      const cashCoveredFee1 =
+        protocolFee1 < updated.cashReserve1 ? protocolFee1 : updated.cashReserve1;
+
+      updated.reserve0 += totalInterest0 + (protocolFee0 - cashCoveredFee0);
+      updated.reserve1 += totalInterest1 + (protocolFee1 - cashCoveredFee1);
+      updated.cashReserve0 -= cashCoveredFee0;
+      updated.cashReserve1 -= cashCoveredFee1;
+      updated.lastUpdate = currentSlot;
+    }
+  }
+
+  return updated;
+}
+
+function constructVirtualReservesAtPessimisticPrice(
+  collateralSpotReserve: bigint,
+  debtSpotReserve: bigint,
+  collateralEmaPriceNad: bigint,
+  collateralDirectionalEmaPriceNad: bigint,
+): [bigint, bigint] {
+  if (collateralSpotReserve < MIN_LIQUIDITY || debtSpotReserve < MIN_LIQUIDITY) {
+    return [0n, 0n];
+  }
+
+  const pessimisticPrice =
+    collateralDirectionalEmaPriceNad < collateralEmaPriceNad
+      ? collateralDirectionalEmaPriceNad
+      : collateralEmaPriceNad;
+
+  if (pessimisticPrice === 0n) {
+    return [collateralSpotReserve, debtSpotReserve];
+  }
+
+  const spotK = collateralSpotReserve * debtSpotReserve;
+  const collateralVirt = sqrtBigInt((spotK * NAD) / pessimisticPrice);
+  const debtVirt = sqrtBigInt((spotK * pessimisticPrice) / NAD);
+  return [collateralVirt, debtVirt];
+}
+
+function cpAmountOut(reserveIn: bigint, reserveOut: bigint, amountIn: bigint): bigint {
+  const denominator = reserveIn + amountIn;
+  if (denominator === 0n) {
+    throw new Error("cp amount out denominator is zero");
+  }
+  return (amountIn * reserveOut) / denominator;
+}
+
+function cpAmountIn(reserveIn: bigint, reserveOut: bigint, amountOut: bigint): bigint {
+  const denominator = reserveOut - amountOut;
+  if (denominator <= 0n) {
+    throw new Error("cp amount in denominator is non-positive");
+  }
+  return ceilDiv(amountOut * reserveIn, denominator);
+}
+
+function asNumber(value: bigint, label: string): number {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`${label} exceeds MAX_SAFE_INTEGER`);
+  }
+  return Number(value);
+}
+
+function quoteBorrowLimit(
+  pair: PairSnapshot,
+  collateralSide: CollateralSide,
+  collateralAmount: bigint,
+  useHealthAdjustedProxy: boolean,
+): BorrowLimitQuote {
+  const collateralEmaPriceNad =
+    collateralSide === "token0" ? pair.lastPrice0Symmetric : pair.lastPrice1Symmetric;
+  const collateralDirectionalEmaPriceNad =
+    collateralSide === "token0" ? pair.lastPrice0Directional : pair.lastPrice1Directional;
+  const collateralReserve = collateralSide === "token0" ? pair.reserve0 : pair.reserve1;
+  const debtReserve = collateralSide === "token0" ? pair.reserve1 : pair.reserve0;
+  const totalDebt = collateralSide === "token0" ? pair.totalDebt1 : pair.totalDebt0;
+  const totalCollateralForSide =
+    collateralSide === "token0" ? pair.totalCollateral0 : pair.totalCollateral1;
+
+  if (
+    collateralAmount === 0n ||
+    collateralEmaPriceNad === 0n ||
+    collateralDirectionalEmaPriceNad === 0n
+  ) {
+    return { borrowLimit: 0n, maxCfBps: 0, liquidationCfBps: 0 };
+  }
+
+  const [collateralVirt, debtVirt] = constructVirtualReservesAtPessimisticPrice(
+    collateralReserve,
+    debtReserve,
+    collateralEmaPriceNad,
+    collateralDirectionalEmaPriceNad,
+  );
+
+  const collateralValueWithImpact = cpAmountOut(collateralVirt, debtVirt, collateralAmount);
+
+  let baseCfBps: bigint;
+  const fixedCfBps = pair.fixedCfBps;
+  if (fixedCfBps != null) {
+    baseCfBps = BigInt(fixedCfBps);
+  } else {
+    if (debtReserve === 0n) {
+      return { borrowLimit: 0n, maxCfBps: 0, liquidationCfBps: 0 };
+    }
+
+    let effectiveTotalDebt = totalDebt;
+    if (useHealthAdjustedProxy && totalDebt > 0n) {
+      const poolCollateralValueWithImpact = cpAmountOut(
+        collateralVirt,
+        debtVirt,
+        totalCollateralForSide,
+      );
+      const rawEffective = ceilDiv(totalDebt * totalDebt, poolCollateralValueWithImpact > 0n ? poolCollateralValueWithImpact : 1n);
+      effectiveTotalDebt = rawEffective < totalDebt ? rawEffective : totalDebt;
+    }
+
+    const utilizedCollateral = cpAmountIn(collateralVirt, debtVirt, effectiveTotalDebt);
+    const maxAllowedTotalDebt = cpAmountOut(
+      collateralVirt,
+      debtVirt,
+      utilizedCollateral + collateralAmount,
+    );
+    const userMaxDebt =
+      maxAllowedTotalDebt > effectiveTotalDebt ? maxAllowedTotalDebt - effectiveTotalDebt : 0n;
+
+    baseCfBps =
+      collateralValueWithImpact === 0n
+        ? 0n
+        : (userMaxDebt * BPS_DENOMINATOR) / collateralValueWithImpact;
+  }
+
+  let liquidationCfBps: bigint;
+  if (fixedCfBps != null) {
+    const shrunk =
+      (collateralDirectionalEmaPriceNad * baseCfBps) /
+      (collateralEmaPriceNad === 0n ? 1n : collateralEmaPriceNad);
+    const capped = baseCfBps < shrunk ? baseCfBps : shrunk;
+    liquidationCfBps = capped > 100n ? capped : 100n;
+  } else {
+    liquidationCfBps =
+      baseCfBps < MAX_COLLATERAL_FACTOR_BPS ? baseCfBps : MAX_COLLATERAL_FACTOR_BPS;
+  }
+
+  const maxAllowedCfBps =
+    (liquidationCfBps * (BPS_DENOMINATOR - LTV_BUFFER_BPS)) / BPS_DENOMINATOR;
+  const borrowLimit = (collateralValueWithImpact * maxAllowedCfBps) / BPS_DENOMINATOR;
+
+  return {
+    borrowLimit,
+    maxCfBps: asNumber(maxAllowedCfBps, "maxAllowedCfBps"),
+    liquidationCfBps: asNumber(liquidationCfBps, "liquidationCfBps"),
+  };
+}
+
+function parseBorrowLimitQuoteFromLogs(logs: string[]): BorrowLimitQuote {
+  const line = logs.find((entry) => entry.includes("GetBorrowLimitAndCfBpsForCollateral"));
+  if (!line) {
+    throw new Error(`Borrow-limit log not found in simulation logs:\n${logs.join("\n")}`);
+  }
+
+  const match = line.match(
+    /GetBorrowLimitAndCfBpsForCollateral:\s*\(U64\((\d+)\),\s*U16\((\d+)\),\s*U16\((\d+)\)\)/,
+  );
+
+  if (!match) {
+    throw new Error(`Could not parse borrow-limit log line: ${line}`);
+  }
+
+  return {
+    borrowLimit: BigInt(match[1]),
+    maxCfBps: Number(match[2]),
+    liquidationCfBps: Number(match[3]),
+  };
+}
+
+export function formatBps(bps: number): string {
+  return `${(bps / 100).toFixed(2)}%`;
+}
+
+export function formatTokenAmount(rawAmount: bigint, decimals: number): string {
+  const base = 10n ** BigInt(decimals);
+  const whole = rawAmount / base;
+  const fraction = rawAmount % base;
+  const fractionString = fraction.toString().padStart(decimals, "0").replace(/0+$/, "");
+  return fractionString.length > 0 ? `${whole}.${fractionString}` : whole.toString();
+}
+
+export function buildProgram(provider?: AnchorProvider): Program<Omnipair> {
+  const resolvedProvider = provider ?? AnchorProvider.env();
+  return new Program<Omnipair>(idl as Omnipair, resolvedProvider);
+}
+
+export function getFutarchyAuthorityPda(programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync([Buffer.from("futarchy_authority")], programId)[0];
+}
+
+async function simulateOnchainBorrowLimit(
+  program: Program<Omnipair>,
+  pair: PairSnapshot,
+  futarchyAuthority: PublicKey,
+  collateralMint: PublicKey,
+  collateralAmount: bigint,
+): Promise<BorrowLimitQuote> {
+  const simulation = await program.methods
+    .viewPairData(
+      { getBorrowLimitAndCfBpsForCollateral: {} },
+      {
+        amount: new BN(asNumber(collateralAmount, "collateralAmount")),
+        tokenMint: collateralMint,
+        debtAmount: null,
+      },
+    )
+    .accountsPartial({
+      pair: pair.address,
+      rateModel: pair.rateModel,
+      futarchyAuthority,
+    })
+    .simulate();
+
+  const logs = (((simulation as any).raw ?? (simulation as any).logs ?? []) as string[]).map(String);
+  return parseBorrowLimitQuoteFromLogs(logs);
+}
+
+export async function runValidationCase(
+  program: Program<Omnipair>,
+  validationCase: ValidationCase,
+): Promise<ValidationResult> {
+  const pairAddress = new PublicKey(validationCase.pairAddress);
+  const pairAccount = await program.account.pair.fetch(pairAddress);
+  const normalizedPair = normalizePair(pairAddress, pairAccount);
+  const rateModelAccount = await program.account.rateModel.fetch(normalizedPair.rateModel);
+  const futarchyAuthorityPda = getFutarchyAuthorityPda(program.programId);
+  const futarchyAuthorityAccount =
+    await program.account.futarchyAuthority.fetch(futarchyAuthorityPda);
+  const currentSlot = BigInt(await program.provider.connection.getSlot("confirmed"));
+
+  const updatedPair = updatePairForView(
+    normalizedPair,
+    normalizeRateModel(rateModelAccount),
+    normalizeFutarchyAuthority(futarchyAuthorityAccount),
+    currentSlot,
+  );
+
+  const collateralMint =
+    validationCase.collateralSide === "token0" ? updatedPair.token0 : updatedPair.token1;
+  const debtMint =
+    validationCase.collateralSide === "token0" ? updatedPair.token1 : updatedPair.token0;
+  const collateralReserve =
+    validationCase.collateralSide === "token0" ? updatedPair.reserve0 : updatedPair.reserve1;
+  const collateralAmount = collateralReserve / 100n;
+  const debtDecimals =
+    validationCase.collateralSide === "token0"
+      ? updatedPair.token1Decimals
+      : updatedPair.token0Decimals;
+  const collateralDecimals =
+    validationCase.collateralSide === "token0"
+      ? updatedPair.token0Decimals
+      : updatedPair.token1Decimals;
+
+  const legacy = quoteBorrowLimit(
+    updatedPair,
+    validationCase.collateralSide,
+    collateralAmount,
+    false,
+  );
+  const proposedOffchain = quoteBorrowLimit(
+    updatedPair,
+    validationCase.collateralSide,
+    collateralAmount,
+    true,
+  );
+  const proposedOnchain = await simulateOnchainBorrowLimit(
+    program,
+    normalizedPair,
+    futarchyAuthorityPda,
+    collateralMint,
+    collateralAmount,
+  );
+
+  return {
+    label: validationCase.label,
+    pairAddress: validationCase.pairAddress,
+    collateralSide: validationCase.collateralSide,
+    collateralAmount,
+    collateralMint,
+    debtMint,
+    collateralDecimals,
+    debtDecimals,
+    legacy,
+    proposedOffchain,
+    proposedOnchain,
+  };
+}

--- a/scripts/validate_health_adjusted_ltv.ts
+++ b/scripts/validate_health_adjusted_ltv.ts
@@ -1,0 +1,85 @@
+import { AnchorProvider } from "@coral-xyz/anchor";
+import {
+  buildProgram,
+  formatBps,
+  formatTokenAmount,
+  runValidationCase,
+  type CollateralSide,
+  type ValidationCase,
+} from "./utils/health_adjusted_ltv.ts";
+
+type CliArgs = {
+  pairAddress: string;
+  collateralSide: CollateralSide;
+  label: string;
+};
+
+function parseArgs(argv: string[]): CliArgs {
+  const defaults: CliArgs = {
+    pairAddress: "3cPJTS5kfD7414aTRPcyBrA55aSx8csCUPWsrS4mnFWV",
+    collateralSide: "token0",
+    label: "SOL / USDC",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--pair" && argv[index + 1]) {
+      defaults.pairAddress = argv[index + 1];
+      index += 1;
+    } else if (value === "--side" && argv[index + 1]) {
+      const side = argv[index + 1];
+      if (side !== "token0" && side !== "token1") {
+        throw new Error(`Unsupported side "${side}". Use token0 or token1.`);
+      }
+      defaults.collateralSide = side;
+      index += 1;
+    } else if (value === "--label" && argv[index + 1]) {
+      defaults.label = argv[index + 1];
+      index += 1;
+    }
+  }
+
+  return defaults;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const provider = AnchorProvider.env();
+  const program = buildProgram(provider);
+
+  const validationCase: ValidationCase = {
+    label: args.label,
+    pairAddress: args.pairAddress,
+    collateralSide: args.collateralSide,
+  };
+
+  const result = await runValidationCase(program, validationCase);
+  console.log(`Health-Adjusted Dynamic LTV Validation`);
+  console.log(`RPC: ${provider.connection.rpcEndpoint}`);
+  console.log(`Pair: ${result.label} (${result.pairAddress})`);
+  console.log(`Collateral side: ${result.collateralSide}`);
+  console.log(
+    `Collateral amount (1% reserve): ${formatTokenAmount(result.collateralAmount, result.collateralDecimals)} collateral tokens`,
+  );
+  console.log("");
+  console.log(`Legacy max LTV: ${formatBps(result.legacy.maxCfBps)}`);
+  console.log(`Legacy liquidation CF: ${formatBps(result.legacy.liquidationCfBps)}`);
+  console.log(`Legacy borrow limit: ${formatTokenAmount(result.legacy.borrowLimit, result.debtDecimals)} debt tokens`);
+  console.log("");
+  console.log(`Proposed max LTV (off-chain): ${formatBps(result.proposedOffchain.maxCfBps)}`);
+  console.log(`Proposed liquidation CF (off-chain): ${formatBps(result.proposedOffchain.liquidationCfBps)}`);
+  console.log(`Proposed borrow limit (off-chain): ${formatTokenAmount(result.proposedOffchain.borrowLimit, result.debtDecimals)} debt tokens`);
+  console.log("");
+  console.log(`Proposed max LTV (on-chain view): ${formatBps(result.proposedOnchain.maxCfBps)}`);
+  console.log(`Proposed liquidation CF (on-chain view): ${formatBps(result.proposedOnchain.liquidationCfBps)}`);
+  console.log(`Proposed borrow limit (on-chain view): ${formatTokenAmount(result.proposedOnchain.borrowLimit, result.debtDecimals)} debt tokens`);
+  console.log("");
+  const deltaBps = result.proposedOnchain.maxCfBps - result.legacy.maxCfBps;
+  const deltaPct = (deltaBps / 100).toFixed(2);
+  console.log(`Delta max LTV (legacy -> on-chain): ${deltaPct}%`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/validate_health_adjusted_ltv_fork.ts
+++ b/scripts/validate_health_adjusted_ltv_fork.ts
@@ -1,0 +1,79 @@
+import { AnchorProvider } from "@coral-xyz/anchor";
+import {
+  buildProgram,
+  formatBps,
+  formatTokenAmount,
+  runValidationCase,
+  type ValidationCase,
+} from "./utils/health_adjusted_ltv.ts";
+
+const FORK_CASES: ValidationCase[] = [
+  {
+    label: "LOYAL / USDC",
+    pairAddress: "DYMhC9dXEpbRdwYSEPUjubj88udSgNYMpPQXENUh9bxE",
+    collateralSide: "token0",
+  },
+  {
+    label: "SOL / USDC",
+    pairAddress: "3cPJTS5kfD7414aTRPcyBrA55aSx8csCUPWsrS4mnFWV",
+    collateralSide: "token0",
+  },
+  {
+    label: "USDC / USDT",
+    pairAddress: "G7enNSGb5k264XRJCPuUXxAjQrWSEvu9qvWe4rg8ADAv",
+    collateralSide: "token0",
+  },
+];
+
+async function main() {
+  const provider = AnchorProvider.env();
+  const program = buildProgram(provider);
+  const results = [];
+
+  console.log(`Surfpool fork validation`);
+  console.log(`RPC: ${provider.connection.rpcEndpoint}`);
+  console.log("");
+
+  for (const validationCase of FORK_CASES) {
+    const result = await runValidationCase(program, validationCase);
+    results.push(result);
+
+    const deltaBps = result.proposedOnchain.maxCfBps - result.legacy.maxCfBps;
+    console.log(`${result.label} (${result.pairAddress})`);
+    console.log(`  side: ${result.collateralSide}`);
+    console.log(
+      `  collateral amount: ${formatTokenAmount(result.collateralAmount, result.collateralDecimals)}`,
+    );
+    console.log(
+      `  legacy LTV: ${formatBps(result.legacy.maxCfBps)} | proposed LTV: ${formatBps(result.proposedOnchain.maxCfBps)} | delta: ${(deltaBps / 100).toFixed(2)}%`,
+    );
+    console.log(
+      `  legacy liq CF: ${formatBps(result.legacy.liquidationCfBps)} | proposed liq CF: ${formatBps(result.proposedOnchain.liquidationCfBps)}`,
+    );
+    console.log(
+      `  legacy borrow limit: ${formatTokenAmount(result.legacy.borrowLimit, result.debtDecimals)} | proposed borrow limit: ${formatTokenAmount(result.proposedOnchain.borrowLimit, result.debtDecimals)}`,
+    );
+    console.log("");
+  }
+
+  const [loyalUsdc, solUsdc, usdcUsdt] = results;
+
+  if (loyalUsdc.proposedOnchain.maxCfBps <= loyalUsdc.legacy.maxCfBps) {
+    throw new Error("Expected LOYAL / USDC proposed max LTV to be above legacy baseline");
+  }
+  if (solUsdc.proposedOnchain.maxCfBps <= solUsdc.legacy.maxCfBps) {
+    throw new Error("Expected SOL / USDC proposed max LTV to be above legacy baseline");
+  }
+
+  const controlDelta = Math.abs(usdcUsdt.proposedOnchain.maxCfBps - usdcUsdt.legacy.maxCfBps);
+  if (controlDelta > 5) {
+    throw new Error(
+      `Expected USDC / USDT control delta to stay within 5 bps, got ${controlDelta} bps`,
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This PR implements the no-migration v1 of health-adjusted dynamic LTV for dynamic-CF pairs.

Instead of treating raw `total_debt` as the crowding baseline, the dynamic borrow-limit path now uses a coherent effective-debt proxy derived from pool collateral coverage on the relevant collateral side:

```text
P* = min(directional_ema_price, ema_price)
x_virt, y_virt = virtual reserves at P*

V_pool = amount_out(x_virt, y_virt, total_pool_collateral_for_that_side)
D_eff = min(total_debt, ceil(total_debt^2 / max(V_pool, 1)))
U_eff = amount_in(x_virt, y_virt, D_eff)
max_total_debt_eff = amount_out(x_virt, y_virt, U_eff + user_collateral)
user_max_debt = max_total_debt_eff - D_eff
```

The fixed-CF path is unchanged.

## What changed

- extend `pessimistic_max_debt(...)` to accept side-specific pool collateral
- compute `D_eff` and use it coherently for both occupancy (`U_eff`) and subtraction
- add `Pair::get_max_debt_and_cf_bps_for_collateral_with_overrides(...)`
- use post-state pool collateral overrides in `remove_collateral.validate_remove`
- use post-liquidation pool debt and collateral overrides when refreshing liquidation CF in `liquidate`
- add a local TS validation script and a Surfpool fork validation script

## Scope

This is intentionally the simple pair-level proxy version.

- no account layout changes
- no migrations / reallocations
- uses existing `pair.total_collateral0/1` as the pool-health proxy
- recognized-collateral / per-position anti-manipulation accounting is explicitly out of scope for this PR

## Validation

### Rust

Targeted new/updated tests cover:

- `D_eff = 0` when `total_debt = 0`
- `D_eff = total_debt` when pool collateral value is too small
- `D_eff` decreases as side collateral increases
- uncapped healthy-pool examples get higher dynamic CF / LTV
- capped paths remain capped
- fixed-CF behavior is unchanged
- remove-collateral validation uses reduced pool collateral
- liquidation CF refresh uses post-liquidation pool debt + collateral

`cargo test -p omnipair --lib` still fails in the preexisting `state::rate_model` suite on this branch/worktree:

- `test_default_matches_original_high_util`
- `test_default_matches_original_low_util`
- `test_faster_half_life_adjusts_quicker`
- `test_uncapped_rate_grows_exponentially`

The health-adjusted LTV tests added in this PR pass.

### Surfpool mainnet fork

Validated on a local Surfpool mainnet fork after upgrading the forked `omnix...` program with the branch build.

Representative results for a standardized collateral amount of 1% of the relevant reserve:

- `LOYAL / USDC`: `36.66% -> 62.36%` max LTV (`+25.70 pp`)
- `SOL / USDC`: `48.13% -> 68.49%` max LTV (`+20.36 pp`)
- `USDC / USDT`: `85.50% -> 85.50%` max LTV (`0.00 pp`, capped control)

These came from the local validation scripts added in this PR:

- `yarn validate-health-ltv`
- `yarn validate-health-ltv-fork`

