### PR TITLE
revert: accidental v0.10.3 version bump

### DIFF
--- a/packages/program-interface/package.json
+++ b/packages/program-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omnipair/program-interface",
-  "version": "0.10.3",
+  "version": "0.10.2",
   "description": "Omnipair program IDL, TypeScript types, and constants",
   "license": "MIT",
   "author": "Omnipair <security@omnipair.fi>",

--- a/programs/omnipair/Cargo.toml
+++ b/programs/omnipair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnipair"
-version = "0.10.3"
+version = "0.10.2"
 description = "Oracless spot and margin money market protocol"
 edition = "2021"
 resolver = "2"


### PR DESCRIPTION
This reverts the accidental version bump commit created by the mistaken release workflow run.

Context:
- `v0.10.3` release and tag have already been deleted
- `v0.10.2` is marked latest again
- the deployed program matches `v0.10.2`, so `main` should reflect that version line too

This PR only restores the manifest versions:
- `programs/omnipair/Cargo.toml`
- `packages/program-interface/package.json`

No program logic or binary changes.
