### PR TITLE
feat: add stressed liquidation exposure

### DIFF
--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -15,6 +15,8 @@ pub const MAX_COLLATERAL_FACTOR_BPS: u16 = 8_500; // 85% cap for dynamic collate
 #[constant]
 pub const LTV_BUFFER_BPS: u16 = 500; // 5% buffer between borrow limit and liquidation threshold
 #[constant]
+pub const EFFECTIVE_DEBT_MULTIPLIER_BPS: u16 = 7_000; // Dynamic CF assumes 70% of total debt unwinds at once
+#[constant]
 pub const FLASHLOAN_FEE_BPS: u16 = 5; // 0.05%
 #[constant]
 pub const LIQUIDATION_INCENTIVE_BPS: u16 = 50; // 0.5% liquidation incentive for caller

--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -15,7 +15,7 @@ pub const MAX_COLLATERAL_FACTOR_BPS: u16 = 8_500; // 85% cap for dynamic collate
 #[constant]
 pub const LTV_BUFFER_BPS: u16 = 500; // 5% buffer between borrow limit and liquidation threshold
 #[constant]
-pub const EFFECTIVE_DEBT_MULTIPLIER_BPS: u16 = 7_000; // Dynamic CF assumes 70% of total debt unwinds at once
+pub const STRESSED_LIQUIDATION_EXPOSURE_BPS: u16 = 7_000; // Dynamic CF prices 70% of debt as liquidation exposure
 #[constant]
 pub const FLASHLOAN_FEE_BPS: u16 = 5; // 0.05%
 #[constant]

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -457,7 +457,7 @@ mod tests {
             directional_ema_price,
         );
 
-        assert_eq!(remaining, 208_039);
+        assert_eq!(remaining, 200_001);
         assert!(
             post_withdraw_borrow_limit(
                 remaining,
@@ -470,8 +470,8 @@ mod tests {
             "post-withdraw borrow-limit check should reject the one-step impact inverse"
         );
         assert!(
-            user_debt >= refreshed_limit,
-            "one-step impact inverse should reproduce the dynamic-CF liquidation regression"
+            user_debt < refreshed_limit,
+            "70% effective debt keeps this inverse withdrawal above liquidation, while borrow-limit validation still rejects it"
         );
     }
 
@@ -485,7 +485,7 @@ mod tests {
         let user_debt = 134_583;
         let total_debt = user_debt;
 
-        let safe_remaining = 226_185;
+        let safe_remaining = 204_685;
         let safe_withdrawal = user_collateral - safe_remaining;
         let refreshed_limit = refreshed_liquidation_limit(
             safe_remaining,
@@ -496,7 +496,7 @@ mod tests {
             directional_ema_price,
         );
 
-        assert_eq!(safe_withdrawal, 1_773_815);
+        assert_eq!(safe_withdrawal, 1_795_315);
         assert!(
             post_withdraw_borrow_limit(
                 safe_remaining,

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -471,7 +471,7 @@ mod tests {
         );
         assert!(
             user_debt < refreshed_limit,
-            "70% effective debt keeps this inverse withdrawal above liquidation, while borrow-limit validation still rejects it"
+            "70% stressed liquidation debt keeps this inverse withdrawal above liquidation, while borrow-limit validation still rejects it"
         );
     }
 

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -51,10 +51,19 @@ impl<'info> CommonAdjustCollateral<'info> {
                 .checked_sub(withdraw_amount)
                 .ok_or(ErrorCode::Overflow)?;
             let collateral_token = if is_collateral_token0 { self.pair.token0 } else { self.pair.token1 };
-            let (post_withdraw_borrow_limit, _, _) = self.pair.get_max_debt_and_cf_bps_for_collateral(
+            let total_collateral_for_side = if is_collateral_token0 {
+                self.pair.total_collateral0
+            } else {
+                self.pair.total_collateral1
+            };
+            let post_withdraw_total_collateral = total_collateral_for_side
+                .checked_sub(withdraw_amount)
+                .ok_or(ErrorCode::Overflow)?;
+            let (post_withdraw_borrow_limit, _, _) = self.pair.get_max_debt_and_cf_bps_for_collateral_with_total_collateral(
                 &self.pair,
                 &collateral_token,
                 remaining_collateral,
+                Some(post_withdraw_total_collateral),
             )?;
             require_gte!(
                 post_withdraw_borrow_limit,
@@ -205,6 +214,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            user_collateral,
             None,
         )
         .unwrap();
@@ -239,6 +249,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            user_collateral,
             None,
         )
         .unwrap();
@@ -280,6 +291,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            user_collateral,
             None,
         )
         .unwrap();
@@ -327,6 +339,7 @@ mod tests {
             collateral_reserve,
             debt_reserve,
             total_debt,
+            user_collateral,
             None,
         )
         .unwrap();
@@ -369,6 +382,7 @@ mod tests {
                 collateral_reserve,
                 debt_reserve,
                 0,
+                user_collateral,
                 None,
             )
             .unwrap();

--- a/programs/omnipair/src/state/pair.rs
+++ b/programs/omnipair/src/state/pair.rs
@@ -286,16 +286,32 @@ impl Pair {
     /// enabling one_way_ema / two_way_ema comparisons rather than raw_spot/ema. 
     /// This provides more front-running resistance by capturing quick price drops, while still smoothing upward movements.
     pub fn get_max_debt_and_cf_bps_for_collateral(&self, pair: &Pair, collateral_token: &Pubkey, collateral_amount: u64) -> Result<(u64, u16, u16)> {
+        self.get_max_debt_and_cf_bps_for_collateral_with_total_collateral(
+            pair,
+            collateral_token,
+            collateral_amount,
+            None,
+        )
+    }
+
+    pub fn get_max_debt_and_cf_bps_for_collateral_with_total_collateral(
+        &self,
+        pair: &Pair,
+        collateral_token: &Pubkey,
+        collateral_amount: u64,
+        total_collateral_override: Option<u64>,
+    ) -> Result<(u64, u16, u16)> {
         let (
             collateral_ema_price,
             collateral_directional_ema_price,
             collateral_amm_reserve,
             debt_amm_reserve,
             debt_total,
+            total_collateral_for_side,
             
         ) = match collateral_token == &pair.token0 {
-            true => (pair.ema_price0_nad(), pair.directional_ema_price0_nad(), pair.reserve0, pair.reserve1, pair.total_debt1),
-            false => (pair.ema_price1_nad(), pair.directional_ema_price1_nad(), pair.reserve1, pair.reserve0, pair.total_debt0),
+            true => (pair.ema_price0_nad(), pair.directional_ema_price0_nad(), pair.reserve0, pair.reserve1, pair.total_debt1, pair.total_collateral0),
+            false => (pair.ema_price1_nad(), pair.directional_ema_price1_nad(), pair.reserve1, pair.reserve0, pair.total_debt0, pair.total_collateral1),
         };
 
         pessimistic_max_debt(
@@ -305,6 +321,7 @@ impl Pair {
             collateral_amm_reserve,
             debt_amm_reserve,
             debt_total,
+            total_collateral_override.unwrap_or(total_collateral_for_side),
             pair.fixed_cf_bps,
         )
     }

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -6,7 +6,8 @@ use std::cmp::min;
 
 const NAD_U128: u128 = NAD as u128;
 const BPS_DENOMINATOR_U128: u128 = BPS_DENOMINATOR as u128;
-const EFFECTIVE_DEBT_MULTIPLIER_BPS_U128: u128 = EFFECTIVE_DEBT_MULTIPLIER_BPS as u128;
+const STRESSED_LIQUIDATION_EXPOSURE_BPS_U128: u128 =
+    STRESSED_LIQUIDATION_EXPOSURE_BPS as u128;
 
 /// Constant Product Curve (invariant: x * y = k)
 ///
@@ -175,14 +176,14 @@ fn calculate_max_allowed_total_debt(
     CPCurve::calculate_amount_out(collateral_ema_reserve, debt_ema_reserve, total_collateral_amount)
 }
 
-/// Applies the dynamic-CF global debt unwind assumption.
+/// Applies the dynamic-CF liquidation exposure assumption.
 ///
 /// The dynamic path does not assume that every open loan liquidates at once.
 /// Instead, it prices the crowding impact from a fixed fraction of aggregate
 /// debt, rounded up so positive debt is not rounded away.
-fn calculate_effective_total_debt(total_debt: u64) -> Result<u64> {
+fn calculate_stressed_liquidation_debt(total_debt: u64) -> Result<u64> {
     let scaled_debt = (total_debt as u128)
-        .checked_mul(EFFECTIVE_DEBT_MULTIPLIER_BPS_U128)
+        .checked_mul(STRESSED_LIQUIDATION_EXPOSURE_BPS_U128)
         .ok_or(ErrorCode::DebtMathOverflow)?;
 
     ceil_div(scaled_debt, BPS_DENOMINATOR_U128)
@@ -200,7 +201,7 @@ fn calculate_effective_total_debt(total_debt: u64) -> Result<u64> {
 /// - collateral_amm_reserve: R0 (raw X units)
 /// - debt_amm_reserve: R1 (raw Y units)
 /// - total_debt: existing total debt (raw Y units). Dynamic CF prices
-///   `EFFECTIVE_DEBT_MULTIPLIER_BPS` of this amount as simultaneous unwind debt.
+///   `STRESSED_LIQUIDATION_EXPOSURE_BPS` of this amount as simultaneous liquidation debt.
 /// - fixed_cf_bps: Optional fixed collateral factor. If Some, uses this directly instead of AMM-based CF
 ///
 /// Returns:
@@ -250,9 +251,9 @@ pub fn pessimistic_max_debt(
         }
 
         // 0. Calculate utilized collateral with price impact using virtual reserves at pessimistic price.
-        let effective_total_debt = calculate_effective_total_debt(total_debt)?;
+        let stressed_liquidation_debt = calculate_stressed_liquidation_debt(total_debt)?;
         let utilized_collateral = calculate_utilized_collateral_with_impact(
-            effective_total_debt,
+            stressed_liquidation_debt,
             collateral_amm_reserve, 
             debt_amm_reserve,
             collateral_directional_ema_price_nad,
@@ -271,7 +272,7 @@ pub fn pessimistic_max_debt(
 
         // 2. Calculate user max debt.
         let user_max_debt = max_allowed_total_debt
-            .checked_sub(effective_total_debt)
+            .checked_sub(stressed_liquidation_debt)
             .unwrap_or(0);
 
         // 3. Calculate base CF = user max debt * BPS_DENOMINATOR / V_impact
@@ -615,7 +616,7 @@ mod tests {
         let (l0, cf0, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 0, None).unwrap();
         assert_eq!((l0, cf0), (269_166, 8075));
         
-        // @200k: effective_debt=140k, user_max=258,601,
+        // @200k: stressed_liquidation_debt=140k, user_max=258,601,
         //        base_cf=258,601*10000/333,333=7758, max_cf=7370
         //        limit=333,333*7370/10000=245,666
         let (l200k, cf200k, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, None).unwrap();
@@ -628,15 +629,15 @@ mod tests {
     }
 
     #[test]
-    fn effective_total_debt_uses_7000_bps() {
-        assert_eq!(calculate_effective_total_debt(0).unwrap(), 0);
-        assert_eq!(calculate_effective_total_debt(1).unwrap(), 1);
-        assert_eq!(calculate_effective_total_debt(200_000).unwrap(), 140_000);
-        assert_eq!(calculate_effective_total_debt(200_001).unwrap(), 140_001);
+    fn stressed_liquidation_debt_uses_7000_bps() {
+        assert_eq!(calculate_stressed_liquidation_debt(0).unwrap(), 0);
+        assert_eq!(calculate_stressed_liquidation_debt(1).unwrap(), 1);
+        assert_eq!(calculate_stressed_liquidation_debt(200_000).unwrap(), 140_000);
+        assert_eq!(calculate_stressed_liquidation_debt(200_001).unwrap(), 140_001);
     }
 
     #[test]
-    fn effective_debt_multiplier_raises_uncapped_dynamic_cf() {
+    fn stressed_liquidation_exposure_raises_uncapped_dynamic_cf() {
         let legacy = legacy_dynamic_pessimistic_max_debt(
             500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000,
         );
@@ -652,7 +653,7 @@ mod tests {
     }
 
     #[test]
-    fn effective_debt_multiplier_does_not_change_fixed_cf_path() {
+    fn stressed_liquidation_exposure_does_not_change_fixed_cf_path() {
         let without_debt = pessimistic_max_debt(
             500_000, NAD, NAD, 1_000_000, 1_000_000, 0, Some(5_000),
         ).unwrap();

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -192,6 +192,33 @@ fn calculate_stressed_liquidation_debt(total_debt: u64) -> Result<u64> {
         .map_err(|_| ErrorCode::DebtMathOverflow.into())
 }
 
+fn calculate_pro_rata_collateral_value_with_impact(
+    collateral_ema_reserve: u64,
+    debt_ema_reserve: u64,
+    collateral_amount: u64,
+    total_collateral_for_side: u64,
+) -> Result<u128> {
+    if total_collateral_for_side <= collateral_amount {
+        return Ok(CPCurve::calculate_amount_out(
+            collateral_ema_reserve,
+            debt_ema_reserve,
+            collateral_amount,
+        )? as u128);
+    }
+
+    let total_collateral_value_with_impact = CPCurve::calculate_amount_out(
+        collateral_ema_reserve,
+        debt_ema_reserve,
+        total_collateral_for_side,
+    )? as u128;
+
+    total_collateral_value_with_impact
+        .checked_mul(collateral_amount as u128)
+        .ok_or(ErrorCode::OutputAmountOverflow)?
+        .checked_div(total_collateral_for_side as u128)
+        .ok_or(ErrorCode::DenominatorOverflow.into())
+}
+
 /// Maximum borrowable amount of tokenY using either a fixed CF or an impact-aware CF
 ///
 /// Inputs:
@@ -202,6 +229,8 @@ fn calculate_stressed_liquidation_debt(total_debt: u64) -> Result<u64> {
 /// - debt_amm_reserve: R1 (raw Y units)
 /// - total_debt: existing total debt (raw Y units). Dynamic CF prices
 ///   `STRESSED_LIQUIDATION_EXPOSURE_BPS` of this amount as simultaneous liquidation debt.
+/// - total_collateral_for_side: total deposited collateral for this collateral side.
+///   Dynamic CF uses this to cap each position by its pro-rata aggregate impact value.
 /// - fixed_cf_bps: Optional fixed collateral factor. If Some, uses this directly instead of AMM-based CF
 ///
 /// Returns:
@@ -215,6 +244,7 @@ pub fn pessimistic_max_debt(
     collateral_amm_reserve: u64,
     debt_amm_reserve: u64,
     total_debt: u64,
+    total_collateral_for_side: u64,
     fixed_cf_bps: Option<u16>,
 ) -> Result<(u64, u16, u16)> {
     // sanity checks
@@ -249,6 +279,15 @@ pub fn pessimistic_max_debt(
         if debt_amm_reserve == 0 {
             return Ok((0, 0, 0));
         }
+        let pro_rata_collateral_value_with_impact = calculate_pro_rata_collateral_value_with_impact(
+            collateral_ema_reserve,
+            debt_ema_reserve,
+            collateral_amount,
+            total_collateral_for_side,
+        )?;
+        if pro_rata_collateral_value_with_impact == 0 {
+            return Ok((0, 0, 0));
+        }
 
         // 0. Calculate utilized collateral with price impact using virtual reserves at pessimistic price.
         let stressed_liquidation_debt = calculate_stressed_liquidation_debt(total_debt)?;
@@ -275,12 +314,19 @@ pub fn pessimistic_max_debt(
             .checked_sub(stressed_liquidation_debt)
             .unwrap_or(0);
 
-        // 3. Calculate base CF = user max debt * BPS_DENOMINATOR / V_impact
-        //    CF is relative to impact value so it captures only the debt crowding effect.
-        (user_max_debt as u128)
-        .saturating_mul(BPS_DENOMINATOR_U128)
-        .checked_div(collateral_value_with_impact) 
-        .unwrap_or(0) as u64
+        // 3. Cap the user's liquidation debt capacity by their pro-rata share
+        //    of aggregate side collateral value. This keeps the dynamic cap
+        //    additive across split positions while storing a CF that liquidation
+        //    can apply to the position's own impact value.
+        let uncapped_cf_bps = (user_max_debt as u128)
+            .saturating_mul(BPS_DENOMINATOR_U128)
+            .checked_div(collateral_value_with_impact)
+            .unwrap_or(0);
+        let pro_rata_cap_cf_bps = pro_rata_collateral_value_with_impact
+            .saturating_mul(MAX_COLLATERAL_FACTOR_BPS as u128)
+            .checked_div(collateral_value_with_impact)
+            .unwrap_or(0);
+        uncapped_cf_bps.min(pro_rata_cap_cf_bps) as u64
     };
 
     // Apply spot/EMA divergence cap to fixed cf only for preventing EMA lag front-running
@@ -599,7 +645,7 @@ mod tests {
         // user_max=500k, base_cf=500k*10000/500k=10000bps (capped to 8500), max_cf=8075
         // limit = 500k * 8075 / 10000 = 403,750
         let (limit, max_cf, liq_cf) = pessimistic_max_debt(
-            1_000_000, NAD, NAD, 1_000_000, 1_000_000, 0, None
+            1_000_000, NAD, NAD, 1_000_000, 1_000_000, 0, 1_000_000, None
         ).unwrap();
         
         assert_eq!((liq_cf, max_cf, limit), (8500, 8075, 403_750));
@@ -613,13 +659,13 @@ mod tests {
         // impact_value = amount_out(1M, 1M, 500k) = 333,333
         // @0: user_max=333,333, base_cf=333,333*10000/333,333=10000 (capped 8500), max_cf=8075
         //     limit=333,333*8075/10000=269,166
-        let (l0, cf0, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 0, None).unwrap();
+        let (l0, cf0, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 0, 500_000, None).unwrap();
         assert_eq!((l0, cf0), (269_166, 8075));
         
         // @200k: stressed_liquidation_debt=140k, user_max=258,601,
         //        base_cf=258,601*10000/333,333=7758, max_cf=7370
         //        limit=333,333*7370/10000=245,666
-        let (l200k, cf200k, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, None).unwrap();
+        let (l200k, cf200k, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, 500_000, None).unwrap();
         assert_eq!((l200k, cf200k), (245_666, 7370));
         
         assert_eq!(l0 - l200k, 23_500);
@@ -642,7 +688,7 @@ mod tests {
             500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000,
         );
         let adjusted = pessimistic_max_debt(
-            500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, None,
+            500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, 500_000, None,
         ).unwrap();
 
         assert_eq!(legacy, (217_133, 6514, 6857));
@@ -655,14 +701,83 @@ mod tests {
     #[test]
     fn stressed_liquidation_exposure_does_not_change_fixed_cf_path() {
         let without_debt = pessimistic_max_debt(
-            500_000, NAD, NAD, 1_000_000, 1_000_000, 0, Some(5_000),
+            500_000, NAD, NAD, 1_000_000, 1_000_000, 0, 500_000, Some(5_000),
         ).unwrap();
         let with_debt = pessimistic_max_debt(
-            500_000, NAD, NAD, 1_000_000, 1_000_000, 900_000, Some(5_000),
+            500_000, NAD, NAD, 1_000_000, 1_000_000, 900_000, 500_000, Some(5_000),
         ).unwrap();
 
         assert_eq!(without_debt, (158_333, 4_750, 5_000));
         assert_eq!(with_debt, without_debt);
+    }
+
+    #[test]
+    fn dynamic_cf_split_positions_do_not_exceed_single_capacity() {
+        let test_cases = [
+            (1_000_000, 2),
+            (999_999, 3),
+            (1_000_000, 4),
+            (1_000_000, 5),
+            (1_000_000, 10),
+            (1_000_000, 20),
+        ];
+
+        for (total_collateral, splits) in test_cases {
+            let (single_limit, _, single_liquidation_cf) = pessimistic_max_debt(
+                total_collateral, NAD, NAD, 1_000_000, 1_000_000, 0, total_collateral, None,
+            ).unwrap();
+            let single_impact_value =
+                CPCurve::calculate_amount_out(1_000_000, 1_000_000, total_collateral).unwrap();
+            let single_liquidation_limit = (single_impact_value as u128)
+                .saturating_mul(single_liquidation_cf as u128)
+                .checked_div(BPS_DENOMINATOR_U128)
+                .unwrap_or(0);
+            let split_collateral = total_collateral / splits;
+            let split_total_collateral = split_collateral * splits;
+            let mut accumulated_debt = 0;
+            let mut split_limit = 0;
+            let mut split_liquidation_limit = 0u128;
+
+            for _ in 0..splits {
+                let (borrow_limit, _, split_liquidation_cf) = pessimistic_max_debt(
+                    split_collateral,
+                    NAD,
+                    NAD,
+                    1_000_000,
+                    1_000_000,
+                    accumulated_debt,
+                    split_total_collateral,
+                    None,
+                ).unwrap();
+                let split_impact_value =
+                    CPCurve::calculate_amount_out(1_000_000, 1_000_000, split_collateral).unwrap();
+                split_liquidation_limit = split_liquidation_limit.saturating_add(
+                    (split_impact_value as u128)
+                        .saturating_mul(split_liquidation_cf as u128)
+                        .checked_div(BPS_DENOMINATOR_U128)
+                        .unwrap_or(0),
+                );
+                accumulated_debt = accumulated_debt.saturating_add(borrow_limit);
+                split_limit += borrow_limit;
+            }
+
+            assert!(
+                split_limit <= single_limit,
+                "split {} positions borrowed {} > single {} for collateral {}",
+                splits,
+                split_limit,
+                single_limit,
+                split_total_collateral
+            );
+            assert!(
+                split_liquidation_limit <= single_liquidation_limit,
+                "split {} positions liquidation threshold {} > single {} for collateral {}",
+                splits,
+                split_liquidation_limit,
+                single_liquidation_limit,
+                split_total_collateral
+            );
+        }
     }
 
     #[test]
@@ -790,6 +905,7 @@ mod tests {
             collateral_amm_reserve,
             debt_amm_reserve,
             total_debt,
+            collateral_amount,
             None,
         );
         assert!(result.is_ok(), "Should not overflow for large price asymmetry pools");
@@ -967,7 +1083,7 @@ mod tests {
         for (user_coll, label) in &test_cases {
             let (borrow_lim, _, liq_cf) = pessimistic_max_debt(
                 *user_coll, ema_price, ema_price,
-                collateral_reserve, debt_reserve, total_debt, None,
+                collateral_reserve, debt_reserve, total_debt, *user_coll, None,
             ).unwrap();
             let liq_lim = liquidation_limit(*user_coll, liq_cf);
             let buffer = liq_lim.saturating_sub(borrow_lim);
@@ -993,7 +1109,7 @@ mod tests {
         for (user_coll, label) in &test_cases {
             let (borrow_lim, _, liq_cf) = pessimistic_max_debt(
                 *user_coll, ema_price, ema_price,
-                collateral_reserve, debt_reserve, total_debt, Some(fixed_cf),
+                collateral_reserve, debt_reserve, total_debt, *user_coll, Some(fixed_cf),
             ).unwrap();
             let liq_lim = liquidation_limit(*user_coll, liq_cf);
             let buffer = liq_lim.saturating_sub(borrow_lim);
@@ -1017,7 +1133,7 @@ mod tests {
         let large_coll: u64 = 500_000;
         let (borrow_lim, _, liq_cf) = pessimistic_max_debt(
             large_coll, ema_price, ema_price,
-            collateral_reserve, debt_reserve, total_debt, None,
+            collateral_reserve, debt_reserve, total_debt, large_coll, None,
         ).unwrap();
         let liq_lim = liquidation_limit(large_coll, liq_cf);
         assert!(

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -6,6 +6,7 @@ use std::cmp::min;
 
 const NAD_U128: u128 = NAD as u128;
 const BPS_DENOMINATOR_U128: u128 = BPS_DENOMINATOR as u128;
+const EFFECTIVE_DEBT_MULTIPLIER_BPS_U128: u128 = EFFECTIVE_DEBT_MULTIPLIER_BPS as u128;
 
 /// Constant Product Curve (invariant: x * y = k)
 ///
@@ -174,6 +175,22 @@ fn calculate_max_allowed_total_debt(
     CPCurve::calculate_amount_out(collateral_ema_reserve, debt_ema_reserve, total_collateral_amount)
 }
 
+/// Applies the dynamic-CF global debt unwind assumption.
+///
+/// The dynamic path does not assume that every open loan liquidates at once.
+/// Instead, it prices the crowding impact from a fixed fraction of aggregate
+/// debt, rounded up so positive debt is not rounded away.
+fn calculate_effective_total_debt(total_debt: u64) -> Result<u64> {
+    let scaled_debt = (total_debt as u128)
+        .checked_mul(EFFECTIVE_DEBT_MULTIPLIER_BPS_U128)
+        .ok_or(ErrorCode::DebtMathOverflow)?;
+
+    ceil_div(scaled_debt, BPS_DENOMINATOR_U128)
+        .ok_or(ErrorCode::DebtMathOverflow)?
+        .try_into()
+        .map_err(|_| ErrorCode::DebtMathOverflow.into())
+}
+
 /// Maximum borrowable amount of tokenY using either a fixed CF or an impact-aware CF
 ///
 /// Inputs:
@@ -182,7 +199,8 @@ fn calculate_max_allowed_total_debt(
 /// - collateral_directional_ema_price_nad: P_directional_ema (NAD-scaled, Y/X) [~50 slots lagging behind inflated spot price]
 /// - collateral_amm_reserve: R0 (raw X units)
 /// - debt_amm_reserve: R1 (raw Y units)
-/// - total_debt: existing total debt (raw Y units)
+/// - total_debt: existing total debt (raw Y units). Dynamic CF prices
+///   `EFFECTIVE_DEBT_MULTIPLIER_BPS` of this amount as simultaneous unwind debt.
 /// - fixed_cf_bps: Optional fixed collateral factor. If Some, uses this directly instead of AMM-based CF
 ///
 /// Returns:
@@ -232,8 +250,9 @@ pub fn pessimistic_max_debt(
         }
 
         // 0. Calculate utilized collateral with price impact using virtual reserves at pessimistic price.
+        let effective_total_debt = calculate_effective_total_debt(total_debt)?;
         let utilized_collateral = calculate_utilized_collateral_with_impact(
-            total_debt, 
+            effective_total_debt,
             collateral_amm_reserve, 
             debt_amm_reserve,
             collateral_directional_ema_price_nad,
@@ -251,7 +270,9 @@ pub fn pessimistic_max_debt(
         )?;
 
         // 2. Calculate user max debt.
-        let user_max_debt = max_allowed_total_debt.checked_sub(total_debt).unwrap_or(0);
+        let user_max_debt = max_allowed_total_debt
+            .checked_sub(effective_total_debt)
+            .unwrap_or(0);
 
         // 3. Calculate base CF = user max debt * BPS_DENOMINATOR / V_impact
         //    CF is relative to impact value so it captures only the debt crowding effect.
@@ -333,6 +354,56 @@ mod tests {
             utilized_collateral, user_collateral, collateral_reserve, debt_reserve, price, price,
         ).unwrap();
         max_total_debt.saturating_sub(existing_total_debt)
+    }
+
+    fn legacy_dynamic_pessimistic_max_debt(
+        collateral_amount: u64,
+        collateral_ema_price_nad: u64,
+        collateral_directional_ema_price_nad: u64,
+        collateral_amm_reserve: u64,
+        debt_amm_reserve: u64,
+        total_debt: u64,
+    ) -> (u64, u16, u16) {
+        let (collateral_ema_reserve, debt_ema_reserve) = construct_virtual_reserves_at_pessimistic_price(
+            collateral_amm_reserve,
+            debt_amm_reserve,
+            collateral_ema_price_nad,
+            collateral_directional_ema_price_nad,
+        ).unwrap();
+        let collateral_value_with_impact =
+            CPCurve::calculate_amount_out(collateral_ema_reserve, debt_ema_reserve, collateral_amount)
+                .unwrap() as u128;
+        let utilized_collateral = calculate_utilized_collateral_with_impact(
+            total_debt,
+            collateral_amm_reserve,
+            debt_amm_reserve,
+            collateral_directional_ema_price_nad,
+            collateral_ema_price_nad,
+        ).unwrap();
+        let max_allowed_total_debt = calculate_max_allowed_total_debt(
+            utilized_collateral,
+            collateral_amount,
+            collateral_amm_reserve,
+            debt_amm_reserve,
+            collateral_directional_ema_price_nad,
+            collateral_ema_price_nad,
+        ).unwrap();
+        let user_max_debt = max_allowed_total_debt.saturating_sub(total_debt);
+        let base_cf_bps = (user_max_debt as u128)
+            .saturating_mul(BPS_DENOMINATOR_U128)
+            .checked_div(collateral_value_with_impact)
+            .unwrap_or(0) as u64;
+        let liquidation_cf_bps = base_cf_bps.min(MAX_COLLATERAL_FACTOR_BPS as u64) as u16;
+        let max_allowed_cf_bps = ((liquidation_cf_bps as u32)
+            .saturating_mul((BPS_DENOMINATOR - LTV_BUFFER_BPS) as u32)
+            / BPS_DENOMINATOR as u32) as u16;
+        let final_borrow_limit: u64 = collateral_value_with_impact
+            .saturating_mul(max_allowed_cf_bps as u128)
+            .checked_div(BPS_DENOMINATOR_U128)
+            .unwrap_or(0)
+            .min(u64::MAX as u128) as u64;
+
+        (final_borrow_limit, max_allowed_cf_bps, liquidation_cf_bps)
     }
 
     /// Check that split accounts cannot borrow more than a single account.
@@ -544,15 +615,53 @@ mod tests {
         let (l0, cf0, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 0, None).unwrap();
         assert_eq!((l0, cf0), (269_166, 8075));
         
-        // @200k: user_max=228,571, base_cf=228,571*10000/333,333=6857, max_cf=6514
-        //        limit=333,333*6514/10000=217,133
+        // @200k: effective_debt=140k, user_max=258,601,
+        //        base_cf=258,601*10000/333,333=7758, max_cf=7370
+        //        limit=333,333*7370/10000=245,666
         let (l200k, cf200k, _) = pessimistic_max_debt(500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, None).unwrap();
-        assert_eq!((l200k, cf200k), (217_133, 6514));
+        assert_eq!((l200k, cf200k), (245_666, 7370));
         
-        assert_eq!(l0 - l200k, 52_033);
+        assert_eq!(l0 - l200k, 23_500);
 
         println!("=== Pessimistic Max Debt with Existing Debt ===");
         println!("@0: cf={}, limit={} | @200k: cf={}, limit={}", cf0, l0, cf200k, l200k);
+    }
+
+    #[test]
+    fn effective_total_debt_uses_7000_bps() {
+        assert_eq!(calculate_effective_total_debt(0).unwrap(), 0);
+        assert_eq!(calculate_effective_total_debt(1).unwrap(), 1);
+        assert_eq!(calculate_effective_total_debt(200_000).unwrap(), 140_000);
+        assert_eq!(calculate_effective_total_debt(200_001).unwrap(), 140_001);
+    }
+
+    #[test]
+    fn effective_debt_multiplier_raises_uncapped_dynamic_cf() {
+        let legacy = legacy_dynamic_pessimistic_max_debt(
+            500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000,
+        );
+        let adjusted = pessimistic_max_debt(
+            500_000, NAD, NAD, 1_000_000, 1_000_000, 200_000, None,
+        ).unwrap();
+
+        assert_eq!(legacy, (217_133, 6514, 6857));
+        assert_eq!(adjusted, (245_666, 7370, 7758));
+        assert!(adjusted.0 > legacy.0);
+        assert!(adjusted.1 > legacy.1);
+        assert!(adjusted.2 > legacy.2);
+    }
+
+    #[test]
+    fn effective_debt_multiplier_does_not_change_fixed_cf_path() {
+        let without_debt = pessimistic_max_debt(
+            500_000, NAD, NAD, 1_000_000, 1_000_000, 0, Some(5_000),
+        ).unwrap();
+        let with_debt = pessimistic_max_debt(
+            500_000, NAD, NAD, 1_000_000, 1_000_000, 900_000, Some(5_000),
+        ).unwrap();
+
+        assert_eq!(without_debt, (158_333, 4_750, 5_000));
+        assert_eq!(with_debt, without_debt);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `EFFECTIVE_DEBT_MULTIPLIER_BPS = 7_000` for the dynamic collateral-factor path.
- Apply the effective debt amount consistently when calculating utilized collateral and subtracting existing debt capacity.
- Keep fixed-CF behavior unchanged.
- Update remove-collateral regression expectations for the new 70% effective-debt assumption.

## Rationale
This is the simpler v1 capital-efficiency change: dynamic CF no longer prices against 100% of aggregate debt unwinding at once. It uses a hardcoded 70% multiplier while preserving the existing impact-aware valuation and 85% liquidation-CF cap.

## Validation
- `cargo test -p omnipair effective_debt -- --nocapture`
- `cargo test -p omnipair effective_total_debt_uses_7000_bps -- --nocapture`
- `cargo test -p omnipair pessimistic_max_debt_with_existing_debt_values -- --nocapture`
- `cargo test -p omnipair post_withdraw_check -- --nocapture`
- `cargo test -p omnipair gamm_math -- --skip manipulation_bounded_by_ema`
- `cargo test -p omnipair --lib -- --skip manipulation_bounded_by_ema --skip state::rate_model`
