### PR TITLE
fix(omnipair): guard liquidity deltas and withdrawals

### DIFF
--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -23,6 +23,8 @@ pub const LIQUIDATION_PENALTY_BPS: u16 = 300; // 3% total liquidation penalty (0
 #[constant]
 pub const LIQUIDITY_WITHDRAWAL_FEE_BPS: u16 = 100; // 1% fee on liquidity withdrawal (goes to remaining LPs)
 #[constant]
+pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 11_500; // 115% debt coverage required after liquidity withdrawal
+#[constant]
 pub const PAIR_CREATION_FEE_LAMPORTS: u64 = 200_000_000; // 0.2 SOL
 // 3log2(100) = 19.93 secs (with 400ms slot time, this is ~50 slots)
 #[constant]

--- a/programs/omnipair/src/errors.rs
+++ b/programs/omnipair/src/errors.rs
@@ -218,6 +218,18 @@ pub enum ErrorCode {
     #[msg("Cannot remove collateral in reduce-only mode while debt exists")]
     ReduceOnlyHasDebt,
 
+    #[msg("Operation blocked: same-transaction liquidity delta detected")]
+    LiquidityDeltaCircuitBreaker,
+
+    #[msg("Operation blocked: liquidity delta instruction must be top-level")]
+    LiquidityDeltaCircuitBreakerCpi,
+
+    #[msg("Invalid instructions sysvar")]
+    InvalidInstructionsSysvar,
+
+    #[msg("Insufficient post-withdraw debt coverage")]
+    InsufficientPostWithdrawDebtCoverage,
+
     #[msg("Invalid recipient - address does not match configured revenue recipient")]
     InvalidRecipient,
 }

--- a/programs/omnipair/src/instructions/lending/borrow.rs
+++ b/programs/omnipair/src/instructions/lending/borrow.rs
@@ -1,25 +1,131 @@
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::sysvar;
+use anchor_spl::{
+    token::{Mint, Token, TokenAccount},
+    token_interface::Token2022,
+};
+
 use crate::{
     constants::*,
     errors::ErrorCode,
-    events::{AdjustDebtEvent, UserPositionUpdatedEvent, EventMetadata},
-    utils::token::transfer_from_vault_to_user,
+    events::{AdjustDebtEvent, EventMetadata, UserPositionUpdatedEvent},
     generate_gamm_pair_seeds,
-    instructions::lending::common::{CommonAdjustDebt, AdjustDebtArgs},
+    instructions::lending::common::AdjustDebtArgs,
+    state::{
+        futarchy_authority::FutarchyAuthority, pair::Pair, rate_model::RateModel,
+        user_position::UserPosition,
+    },
+    utils::{
+        liquidity_delta_circuit_breaker::require_no_same_tx_liquidity_delta,
+        token::transfer_from_vault_to_user,
+    },
 };
 
-impl<'info> CommonAdjustDebt<'info> {
+#[event_cpi]
+#[derive(Accounts)]
+pub struct Borrow<'info> {
+    #[account(
+        mut,
+        seeds = [
+            PAIR_SEED_PREFIX,
+            pair.token0.as_ref(),
+            pair.token1.as_ref(),
+            pair.params_hash.as_ref()
+        ],
+        bump = pair.bump
+    )]
+    pub pair: Account<'info, Pair>,
+
+    #[account(
+        mut,
+        constraint = user_position.owner == user.key(),
+        constraint = user_position.pair == pair.key(),
+        seeds = [
+            POSITION_SEED_PREFIX,
+            pair.key().as_ref(),
+            user.key().as_ref()
+        ],
+        bump = user_position.bump
+    )]
+    pub user_position: Account<'info, UserPosition>,
+
+    #[account(
+        mut,
+        address = pair.rate_model,
+    )]
+    pub rate_model: Account<'info, RateModel>,
+
+    #[account(
+        seeds = [FUTARCHY_AUTHORITY_SEED_PREFIX],
+        bump = futarchy_authority.bump
+    )]
+    pub futarchy_authority: Account<'info, FutarchyAuthority>,
+
+    #[account(
+        mut,
+        seeds = [
+            RESERVE_VAULT_SEED_PREFIX,
+            pair.key().as_ref(),
+            reserve_token_mint.key().as_ref(),
+        ],
+        bump = pair.get_reserve_vault_bump(&reserve_token_mint.key())
+    )]
+    pub reserve_vault: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        constraint = user_reserve_token_account.mint == pair.token0 || user_reserve_token_account.mint == pair.token1,
+        token::authority = user,
+    )]
+    pub user_reserve_token_account: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        constraint = reserve_token_mint.key() == pair.token0 || reserve_token_mint.key() == pair.token1 @ ErrorCode::InvalidMint
+    )]
+    pub reserve_token_mint: Box<Account<'info, Mint>>,
+
+    pub user: Signer<'info>,
+    pub token_program: Program<'info, Token>,
+    pub token_2022_program: Program<'info, Token2022>,
+    pub system_program: Program<'info, System>,
+
+    /// CHECK: Instructions sysvar used by the liquidity delta circuit breaker.
+    #[account(address = sysvar::instructions::ID @ ErrorCode::InvalidInstructionsSysvar)]
+    pub instructions_sysvar: UncheckedAccount<'info>,
+}
+
+impl<'info> Borrow<'info> {
     pub fn validate_borrow(&self, args: &AdjustDebtArgs) -> Result<()> {
-        let AdjustDebtArgs { amount: borrow_amount } = args;
-        
+        let AdjustDebtArgs {
+            amount: borrow_amount,
+        } = args;
+
+        require_no_same_tx_liquidity_delta(
+            &self.pair.key(),
+            &self.instructions_sysvar.to_account_info(),
+        )?;
+
         // Check reduce-only mode (global or per-pair)
         require!(
-            !self.futarchy_authority.is_reduce_only(self.pair.reduce_only),
+            !self
+                .futarchy_authority
+                .is_reduce_only(self.pair.reduce_only),
             ErrorCode::ReduceOnlyMode
         );
-        
+
         require!(*borrow_amount > 0, ErrorCode::AmountZero);
-        
+
+        Ok(())
+    }
+
+    pub fn update(&mut self) -> Result<()> {
+        let pair_key = self.pair.to_account_info().key();
+        self.pair.update(
+            &self.rate_model,
+            &self.futarchy_authority,
+            pair_key,
+            Some(self.event_authority.to_account_info()),
+        )?;
         Ok(())
     }
 
@@ -34,13 +140,13 @@ impl<'info> CommonAdjustDebt<'info> {
     /// - `vault_token_mint`: Mint address of the token the user wants to borrow.
     /// - `token_vault`: AMM liquidity vault holding the borrowable tokens (pair.token0 or pair.token1 vault).
     /// - `user_token_account`: User's associated token account that will receive the borrowed tokens.
-    /// 
+    ///
     /// Notes:
     /// Only the specified borrow amount of the `vault_token_mint` is transferred.
     /// Tokens are sourced directly from the AMM's liquidity vault (`token_vault`).
-    /// Assumes that collateral checks have already passed via [`CommonAdjustPosition::validate_borrow`].
+    /// Assumes that collateral checks have already passed via [`Borrow::validate_borrow`].
     pub fn handle_borrow(ctx: Context<Self>, args: AdjustDebtArgs) -> Result<()> {
-        let CommonAdjustDebt {
+        let Borrow {
             user_reserve_token_account,
             reserve_token_mint,
             token_program,
@@ -58,7 +164,6 @@ impl<'info> CommonAdjustDebt<'info> {
             false => user_position.calculate_debt1(pair.total_debt1, pair.total_debt1_shares)?,
         };
 
-        
         // If EMA lags behind a falling spot price, there will be a window where the collateral value may be artificially inflated.
         // To prevent bad debt, we compute a pessimistic collateral factor:
         // CF_pessimistic = min(CF_base, P_spot / P_EMA * CF_base)
@@ -68,25 +173,39 @@ impl<'info> CommonAdjustDebt<'info> {
             true => user_position.collateral0,
             false => user_position.collateral1,
         };
-        let (borrow_limit, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(&pair, &collateral_token, collateral_amount)?;
+        let (borrow_limit, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(
+            &pair,
+            &collateral_token,
+            collateral_amount,
+        )?;
         let is_max_borrow = args.amount == u64::MAX;
-        let remaining_borrow_limit = borrow_limit.checked_sub(user_debt).ok_or(ErrorCode::DebtMathOverflow)?;
-        let borrow_amount = if is_max_borrow { remaining_borrow_limit } else { args.amount };
-        
+        let remaining_borrow_limit = borrow_limit
+            .checked_sub(user_debt)
+            .ok_or(ErrorCode::DebtMathOverflow)?;
+        let borrow_amount = if is_max_borrow {
+            remaining_borrow_limit
+        } else {
+            args.amount
+        };
+
         let new_debt = user_debt
-            .checked_add( borrow_amount )
+            .checked_add(borrow_amount)
             .ok_or(ErrorCode::DebtMathOverflow)?;
 
-        require_gte!(
-            borrow_limit,
-            new_debt,
-            ErrorCode::BorrowingPowerExceeded
-        );
+        require_gte!(borrow_limit, new_debt, ErrorCode::BorrowingPowerExceeded);
 
         // r_cash >= r_debt_out
         match is_token0 {
-            true => require_gte!(pair.cash_reserve0, borrow_amount, ErrorCode::InsufficientCashReserve0),
-            false => require_gte!(pair.cash_reserve1, borrow_amount, ErrorCode::InsufficientCashReserve1)
+            true => require_gte!(
+                pair.cash_reserve0,
+                borrow_amount,
+                ErrorCode::InsufficientCashReserve0
+            ),
+            false => require_gte!(
+                pair.cash_reserve1,
+                borrow_amount,
+                ErrorCode::InsufficientCashReserve1
+            ),
         };
 
         // Transfer tokens from vault to user
@@ -103,18 +222,21 @@ impl<'info> CommonAdjustDebt<'info> {
             reserve_token_mint.decimals,
             &[&generate_gamm_pair_seeds!(pair)[..]],
         )?;
-        
+
         user_position.increase_debt(pair, &reserve_token_mint.key(), borrow_amount)?;
-        // update user position fixed CF
-        user_position.set_liquidation_cf_for_debt_token(&reserve_token_mint.key(), &pair, liquidation_cf_bps);
-        
+        user_position.set_liquidation_cf_for_debt_token(
+            &reserve_token_mint.key(),
+            &pair,
+            liquidation_cf_bps,
+        );
+
         // Emit debt adjustment event
         let (amount0, amount1) = if is_token0 {
             (borrow_amount as i64, 0)
         } else {
             (0, borrow_amount as i64)
         };
-        
+
         emit_cpi!(AdjustDebtEvent {
             metadata: EventMetadata::new(user.key(), pair.key()),
             amount0,

--- a/programs/omnipair/src/instructions/lending/borrow.rs
+++ b/programs/omnipair/src/instructions/lending/borrow.rs
@@ -74,7 +74,7 @@ pub struct Borrow<'info> {
 
     #[account(
         mut,
-        constraint = user_reserve_token_account.mint == pair.token0 || user_reserve_token_account.mint == pair.token1,
+        constraint = user_reserve_token_account.mint == reserve_token_mint.key() @ ErrorCode::InvalidMint,
         token::authority = user,
     )]
     pub user_reserve_token_account: Box<Account<'info, TokenAccount>>,
@@ -92,6 +92,18 @@ pub struct Borrow<'info> {
     /// CHECK: Instructions sysvar used by the liquidity delta circuit breaker.
     #[account(address = sysvar::instructions::ID @ ErrorCode::InvalidInstructionsSysvar)]
     pub instructions_sysvar: UncheckedAccount<'info>,
+}
+
+fn resolve_borrow_amount(requested_amount: u64, borrow_limit: u64, user_debt: u64) -> Result<u64> {
+    let borrow_amount = if requested_amount == u64::MAX {
+        borrow_limit
+            .checked_sub(user_debt)
+            .ok_or(ErrorCode::DebtMathOverflow)?
+    } else {
+        requested_amount
+    };
+    require!(borrow_amount > 0, ErrorCode::AmountZero);
+    Ok(borrow_amount)
 }
 
 impl<'info> Borrow<'info> {
@@ -157,7 +169,8 @@ impl<'info> Borrow<'info> {
         } = ctx.accounts;
         let pair = &mut ctx.accounts.pair;
         let debt_token_vault = &ctx.accounts.reserve_vault;
-        let is_token0 = user_reserve_token_account.mint == pair.token0;
+        let debt_token = reserve_token_mint.key();
+        let is_token0 = debt_token == pair.token0;
 
         let user_debt = match is_token0 {
             true => user_position.calculate_debt0(pair.total_debt0, pair.total_debt0_shares)?,
@@ -168,7 +181,7 @@ impl<'info> Borrow<'info> {
         // To prevent bad debt, we compute a pessimistic collateral factor:
         // CF_pessimistic = min(CF_base, P_spot / P_EMA * CF_base)
         // This ensures the solvency invariant: P_spot >= P_EMA * CF
-        let collateral_token = pair.get_collateral_token(&debt_token_vault.mint);
+        let collateral_token = pair.get_collateral_token(&debt_token);
         let collateral_amount = match collateral_token == pair.token0 {
             true => user_position.collateral0,
             false => user_position.collateral1,
@@ -178,15 +191,7 @@ impl<'info> Borrow<'info> {
             &collateral_token,
             collateral_amount,
         )?;
-        let is_max_borrow = args.amount == u64::MAX;
-        let remaining_borrow_limit = borrow_limit
-            .checked_sub(user_debt)
-            .ok_or(ErrorCode::DebtMathOverflow)?;
-        let borrow_amount = if is_max_borrow {
-            remaining_borrow_limit
-        } else {
-            args.amount
-        };
+        let borrow_amount = resolve_borrow_amount(args.amount, borrow_limit, user_debt)?;
 
         let new_debt = user_debt
             .checked_add(borrow_amount)
@@ -223,12 +228,8 @@ impl<'info> Borrow<'info> {
             &[&generate_gamm_pair_seeds!(pair)[..]],
         )?;
 
-        user_position.increase_debt(pair, &reserve_token_mint.key(), borrow_amount)?;
-        user_position.set_liquidation_cf_for_debt_token(
-            &reserve_token_mint.key(),
-            &pair,
-            liquidation_cf_bps,
-        );
+        user_position.increase_debt(pair, &debt_token, borrow_amount)?;
+        user_position.set_liquidation_cf_for_debt_token(&debt_token, &pair, liquidation_cf_bps);
 
         // Emit debt adjustment event
         let (amount0, amount1) = if is_token0 {
@@ -258,5 +259,33 @@ impl<'info> Borrow<'info> {
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_borrow_rejects_zero_resolved_amount() {
+        let err = resolve_borrow_amount(u64::MAX, 100, 100).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::AmountZero));
+    }
+
+    #[test]
+    fn max_borrow_rejects_debt_above_limit() {
+        let err = resolve_borrow_amount(u64::MAX, 100, 101).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::DebtMathOverflow));
+    }
+
+    #[test]
+    fn explicit_borrow_rejects_zero_amount() {
+        let err = resolve_borrow_amount(0, 100, 0).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::AmountZero));
+    }
+
+    #[test]
+    fn max_borrow_resolves_positive_remaining_limit() {
+        assert_eq!(resolve_borrow_amount(u64::MAX, 100, 40).unwrap(), 60);
     }
 }

--- a/programs/omnipair/src/instructions/lending/common.rs
+++ b/programs/omnipair/src/instructions/lending/common.rs
@@ -1,5 +1,6 @@
 use anchor_lang::{
     prelude::*,
+    solana_program::sysvar,
 };
 use anchor_spl::{
     token::{Token, TokenAccount, Mint},
@@ -86,6 +87,10 @@ pub struct CommonAdjustCollateral<'info> {
     pub token_program: Program<'info, Token>,
     pub token_2022_program: Program<'info, Token2022>,
     pub system_program: Program<'info, System>,
+
+    /// CHECK: Instructions sysvar used by the liquidity delta circuit breaker.
+    #[account(address = sysvar::instructions::ID @ ErrorCode::InvalidInstructionsSysvar)]
+    pub instructions_sysvar: UncheckedAccount<'info>,
 }
 
 impl<'info> CommonAdjustCollateral<'info> {

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -4,6 +4,7 @@ use crate::{
     errors::ErrorCode,
     events::{AdjustCollateralEvent, EventMetadata, UserPositionUpdatedEvent},
     utils::token::transfer_from_vault_to_user,
+    utils::liquidity_delta_circuit_breaker::require_no_same_tx_liquidity_delta,
     generate_gamm_pair_seeds,
     instructions::lending::common::{CommonAdjustCollateral, AdjustCollateralArgs},
 };
@@ -12,6 +13,11 @@ impl<'info> CommonAdjustCollateral<'info> {
     pub fn validate_remove(&self, args: &AdjustCollateralArgs) -> Result<()> {
         let AdjustCollateralArgs { amount } = args;
         
+        require_no_same_tx_liquidity_delta(
+            &self.pair.key(),
+            &self.instructions_sysvar.to_account_info(),
+        )?;
+
         require!(*amount > 0, ErrorCode::AmountZero);
 
         let collateral_token = self.user_collateral_token_account.mint;

--- a/programs/omnipair/src/instructions/liquidity/add_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/add_liquidity.rs
@@ -3,6 +3,7 @@ use crate::errors::ErrorCode;
 use crate::constants::*;
 use crate::utils::token::{transfer_from_user_to_vault, token_mint_to};
 use crate::utils::math::ceil_div;
+use crate::utils::liquidity_delta_circuit_breaker::{require_top_level_liquidity_delta_ix, LiquidityDeltaInstruction};
 use crate::generate_gamm_pair_seeds;
 use crate::liquidity::common::{AdjustLiquidity, AddLiquidityArgs};
 use crate::events::{MintEvent, UserLiquidityPositionUpdatedEvent, EventMetadata};
@@ -14,8 +15,15 @@ impl<'info> AdjustLiquidity<'info> {
             user_token1_account,
             futarchy_authority,
             pair,
+            instructions_sysvar,
             .. 
         } = self;
+
+        require_top_level_liquidity_delta_ix(
+            &pair.key(),
+            &instructions_sysvar.to_account_info(),
+            LiquidityDeltaInstruction::AddLiquidity,
+        )?;
 
         // Check reduce-only mode (global or per-pair)
         require!(

--- a/programs/omnipair/src/instructions/liquidity/common.rs
+++ b/programs/omnipair/src/instructions/liquidity/common.rs
@@ -1,5 +1,6 @@
 use anchor_lang::{
     prelude::*,
+    solana_program::sysvar,
 };
 use anchor_spl::{
     token::{Token, TokenAccount, Mint},
@@ -115,6 +116,10 @@ pub struct AdjustLiquidity<'info> {
     pub token_2022_program: Program<'info, Token2022>,
     pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
+
+    /// CHECK: Instructions sysvar used by the liquidity delta circuit breaker.
+    #[account(address = sysvar::instructions::ID @ ErrorCode::InvalidInstructionsSysvar)]
+    pub instructions_sysvar: UncheckedAccount<'info>,
 }
 
 impl<'info> AdjustLiquidity<'info> {
@@ -130,4 +135,3 @@ impl<'info> AdjustLiquidity<'info> {
         Ok(())
     }
 }
-

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -13,8 +13,8 @@ use crate::generate_gamm_pair_seeds;
 use crate::state::{futarchy_authority::FutarchyAuthority, pair::Pair, rate_model::RateModel};
 use crate::utils::gamm_math::{construct_virtual_reserves_at_pessimistic_price, CPCurve};
 use crate::utils::liquidity_delta_circuit_breaker::{
-    require_no_same_tx_add_liquidity, require_top_level_liquidity_delta_ix,
-    LiquidityDeltaInstruction,
+    require_current_ix_is_final, require_no_same_tx_add_liquidity,
+    require_top_level_liquidity_delta_ix, LiquidityDeltaInstruction,
 };
 use crate::utils::math::ceil_div;
 use crate::utils::token::{token_burn, transfer_from_vault_to_user};
@@ -133,6 +133,7 @@ impl<'info> RemoveLiquidity<'info> {
             &self.instructions_sysvar.to_account_info(),
             LiquidityDeltaInstruction::RemoveLiquidity,
         )?;
+        require_current_ix_is_final(&self.instructions_sysvar.to_account_info())?;
         require_no_same_tx_add_liquidity(
             &self.pair.key(),
             &self.instructions_sysvar.to_account_info(),

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -1,11 +1,23 @@
 use anchor_lang::prelude::*;
-use crate::errors::ErrorCode;
+use anchor_lang::solana_program::sysvar;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{Mint, Token, TokenAccount},
+    token_interface::Token2022,
+};
+
 use crate::constants::*;
-use crate::utils::math::ceil_div;
-use crate::utils::token::{transfer_from_vault_to_user, token_burn};
+use crate::errors::ErrorCode;
+use crate::events::{BurnEvent, EventMetadata, UserLiquidityPositionUpdatedEvent};
 use crate::generate_gamm_pair_seeds;
-use crate::liquidity::common::AdjustLiquidity;
-use crate::events::{BurnEvent, UserLiquidityPositionUpdatedEvent, EventMetadata};
+use crate::state::{futarchy_authority::FutarchyAuthority, pair::Pair, rate_model::RateModel};
+use crate::utils::gamm_math::{construct_virtual_reserves_at_pessimistic_price, CPCurve};
+use crate::utils::liquidity_delta_circuit_breaker::{
+    require_no_same_tx_add_liquidity, require_top_level_liquidity_delta_ix,
+    LiquidityDeltaInstruction,
+};
+use crate::utils::math::ceil_div;
+use crate::utils::token::{token_burn, transfer_from_vault_to_user};
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct RemoveLiquidityArgs {
@@ -14,23 +26,139 @@ pub struct RemoveLiquidityArgs {
     pub min_amount1_out: u64,
 }
 
-impl<'info> AdjustLiquidity<'info> {
+#[event_cpi]
+#[derive(Accounts)]
+pub struct RemoveLiquidity<'info> {
+    #[account(
+        mut,
+        seeds = [
+            PAIR_SEED_PREFIX,
+            pair.token0.as_ref(),
+            pair.token1.as_ref(),
+            pair.params_hash.as_ref()
+        ],
+        bump = pair.bump
+    )]
+    pub pair: Account<'info, Pair>,
+
+    #[account(
+        mut,
+        address = pair.rate_model,
+    )]
+    pub rate_model: Account<'info, RateModel>,
+
+    #[account(
+        seeds = [FUTARCHY_AUTHORITY_SEED_PREFIX],
+        bump = futarchy_authority.bump
+    )]
+    pub futarchy_authority: Account<'info, FutarchyAuthority>,
+
+    #[account(
+        mut,
+        seeds = [
+            RESERVE_VAULT_SEED_PREFIX,
+            pair.key().as_ref(),
+            pair.token0.as_ref(),
+        ],
+        bump = pair.vault_bumps.reserve0
+    )]
+    pub reserve0_vault: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        seeds = [
+            RESERVE_VAULT_SEED_PREFIX,
+            pair.key().as_ref(),
+            pair.token1.as_ref(),
+        ],
+        bump = pair.vault_bumps.reserve1
+    )]
+    pub reserve1_vault: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        token::mint = pair.token0,
+        token::authority = user,
+    )]
+    pub user_token0_account: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        token::mint = pair.token1,
+        token::authority = user,
+    )]
+    pub user_token1_account: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        address = pair.token0 @ ErrorCode::InvalidMint
+    )]
+    pub token0_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        address = pair.token1 @ ErrorCode::InvalidMint
+    )]
+    pub token1_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        mut,
+        address = pair.lp_mint @ ErrorCode::InvalidMint,
+    )]
+    pub lp_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        init_if_needed,
+        associated_token::mint = lp_mint,
+        associated_token::authority = user,
+        payer = user,
+        token::token_program = token_program,
+    )]
+    pub user_lp_token_account: Box<Account<'info, TokenAccount>>,
+
+    #[account(mut)]
+    pub user: Signer<'info>,
+    pub token_program: Program<'info, Token>,
+    pub token_2022_program: Program<'info, Token2022>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub system_program: Program<'info, System>,
+
+    /// CHECK: Instructions sysvar used by the liquidity delta circuit breaker.
+    #[account(address = sysvar::instructions::ID @ ErrorCode::InvalidInstructionsSysvar)]
+    pub instructions_sysvar: UncheckedAccount<'info>,
+}
+
+impl<'info> RemoveLiquidity<'info> {
     fn validate_remove(&self, args: &RemoveLiquidityArgs) -> Result<()> {
-        let AdjustLiquidity { 
-            pair,
-            user_lp_token_account,
-            .. 
-        } = self;
+        require_top_level_liquidity_delta_ix(
+            &self.pair.key(),
+            &self.instructions_sysvar.to_account_info(),
+            LiquidityDeltaInstruction::RemoveLiquidity,
+        )?;
+        require_no_same_tx_add_liquidity(
+            &self.pair.key(),
+            &self.instructions_sysvar.to_account_info(),
+        )?;
 
-        let RemoveLiquidityArgs { 
-            liquidity_in,
-            ..
-        } = args;
+        require!(args.liquidity_in > 0, ErrorCode::AmountZero);
+        require!(
+            args.liquidity_in <= self.pair.total_supply,
+            ErrorCode::InsufficientLiquidity
+        );
+        require!(
+            self.user_lp_token_account.amount >= args.liquidity_in,
+            ErrorCode::InsufficientBalance
+        );
 
-        require!(*liquidity_in > 0, ErrorCode::AmountZero);
-        require!(*liquidity_in <= pair.total_supply, ErrorCode::InsufficientLiquidity);
-        require!(user_lp_token_account.amount >= *liquidity_in, ErrorCode::InsufficientBalance);
-        
+        Ok(())
+    }
+
+    pub fn update(&mut self) -> Result<()> {
+        let pair_key = self.pair.to_account_info().key();
+        self.pair.update(
+            &self.rate_model,
+            &self.futarchy_authority,
+            pair_key,
+            Some(self.event_authority.to_account_info()),
+        )?;
         Ok(())
     }
 
@@ -41,7 +169,7 @@ impl<'info> AdjustLiquidity<'info> {
     }
 
     pub fn handle_remove(ctx: Context<Self>, args: RemoveLiquidityArgs) -> Result<()> {
-        let AdjustLiquidity {
+        let RemoveLiquidity {
             pair,
             user_lp_token_account,
             reserve0_vault,
@@ -75,18 +203,26 @@ impl<'info> AdjustLiquidity<'info> {
 
         // Apply withdrawal fee (1%) - fee remains in reserves for remaining LPs
         let fee0 = ceil_div(
-            (amount0_gross as u128).checked_mul(LIQUIDITY_WITHDRAWAL_FEE_BPS as u128)
+            (amount0_gross as u128)
+                .checked_mul(LIQUIDITY_WITHDRAWAL_FEE_BPS as u128)
                 .ok_or(ErrorCode::FeeMathOverflow)?,
-            BPS_DENOMINATOR as u128
-        ).ok_or(ErrorCode::FeeMathOverflow)? as u64;
+            BPS_DENOMINATOR as u128,
+        )
+        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
         let fee1 = ceil_div(
-            (amount1_gross as u128).checked_mul(LIQUIDITY_WITHDRAWAL_FEE_BPS as u128)
+            (amount1_gross as u128)
+                .checked_mul(LIQUIDITY_WITHDRAWAL_FEE_BPS as u128)
                 .ok_or(ErrorCode::FeeMathOverflow)?,
-            BPS_DENOMINATOR as u128
-        ).ok_or(ErrorCode::FeeMathOverflow)? as u64;
+            BPS_DENOMINATOR as u128,
+        )
+        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
 
-        let amount0_out = amount0_gross.checked_sub(fee0).ok_or(ErrorCode::LiquidityMathOverflow)?;
-        let amount1_out = amount1_gross.checked_sub(fee1).ok_or(ErrorCode::LiquidityMathOverflow)?;
+        let amount0_out = amount0_gross
+            .checked_sub(fee0)
+            .ok_or(ErrorCode::LiquidityMathOverflow)?;
+        let amount1_out = amount1_gross
+            .checked_sub(fee1)
+            .ok_or(ErrorCode::LiquidityMathOverflow)?;
 
         // Check if amounts meet minimum (slippage protection)
         require!(
@@ -103,8 +239,26 @@ impl<'info> AdjustLiquidity<'info> {
         //   to be higher than the virtual reserves (r_virtual).
         // - If the invariant r_cash + r_debt = r_virtual is broken, the pool's solvency
         //   assumption (r_virtual >= r_debt) may also be violated.
-        require_gte!(pair.cash_reserve0, amount0_out, ErrorCode::InsufficientCashReserve0);
-        require_gte!(pair.cash_reserve1, amount1_out, ErrorCode::InsufficientCashReserve1);
+        require_gte!(
+            pair.cash_reserve0,
+            amount0_out,
+            ErrorCode::InsufficientCashReserve0
+        );
+        require_gte!(
+            pair.cash_reserve1,
+            amount1_out,
+            ErrorCode::InsufficientCashReserve1
+        );
+
+        let post_reserve0 = pair
+            .reserve0
+            .checked_sub(amount0_out)
+            .ok_or(ErrorCode::ReserveUnderflow)?;
+        let post_reserve1 = pair
+            .reserve1
+            .checked_sub(amount1_out)
+            .ok_or(ErrorCode::ReserveUnderflow)?;
+        validate_post_withdraw_debt_coverage(pair, post_reserve0, post_reserve1)?;
 
         // Transfer tokens from pool to user
         transfer_from_vault_to_user(
@@ -150,18 +304,27 @@ impl<'info> AdjustLiquidity<'info> {
         )?;
 
         // Update reserves
-        pair.reserve0 = pair.reserve0.checked_sub(amount0_out).ok_or(ErrorCode::ReserveUnderflow)?;
-        pair.reserve1 = pair.reserve1.checked_sub(amount1_out).ok_or(ErrorCode::ReserveUnderflow)?;
-        pair.total_supply = pair.total_supply.checked_sub(args.liquidity_in).ok_or(ErrorCode::SupplyUnderflow)?;
+        pair.reserve0 = post_reserve0;
+        pair.reserve1 = post_reserve1;
+        pair.total_supply = pair
+            .total_supply
+            .checked_sub(args.liquidity_in)
+            .ok_or(ErrorCode::SupplyUnderflow)?;
 
         // Update cash reserves
-        pair.cash_reserve0 = pair.cash_reserve0.checked_sub(amount0_out).ok_or(ErrorCode::CashReserveUnderflow)?;
-        pair.cash_reserve1 = pair.cash_reserve1.checked_sub(amount1_out).ok_or(ErrorCode::CashReserveUnderflow)?;
+        pair.cash_reserve0 = pair
+            .cash_reserve0
+            .checked_sub(amount0_out)
+            .ok_or(ErrorCode::CashReserveUnderflow)?;
+        pair.cash_reserve1 = pair
+            .cash_reserve1
+            .checked_sub(amount1_out)
+            .ok_or(ErrorCode::CashReserveUnderflow)?;
 
         // Reload LP token account to get updated balance after burn
         user_lp_token_account.reload()?;
         let user_lp_balance = user_lp_token_account.amount;
-        
+
         // Calculate user's token amounts from LP balance (same formula as add_liquidity)
         let user_token0_amount = (user_lp_balance as u128)
             .checked_mul(pair.reserve0 as u128)
@@ -199,5 +362,144 @@ impl<'info> AdjustLiquidity<'info> {
         });
 
         Ok(())
+    }
+}
+
+fn validate_post_withdraw_debt_coverage(
+    pair: &Pair,
+    post_reserve0: u64,
+    post_reserve1: u64,
+) -> Result<()> {
+    validate_post_withdraw_debt_coverage_with_prices(
+        post_reserve0,
+        post_reserve1,
+        pair.total_debt0,
+        pair.total_debt1,
+        pair.ema_price0_nad(),
+        pair.directional_ema_price0_nad(),
+        pair.ema_price1_nad(),
+        pair.directional_ema_price1_nad(),
+    )
+}
+
+fn validate_post_withdraw_debt_coverage_with_prices(
+    post_reserve0: u64,
+    post_reserve1: u64,
+    total_debt0: u64,
+    total_debt1: u64,
+    token0_ema_price_nad: u64,
+    token0_directional_ema_price_nad: u64,
+    token1_ema_price_nad: u64,
+    token1_directional_ema_price_nad: u64,
+) -> Result<()> {
+    let required_token1_for_debt0 = required_collateral_with_impact(
+        total_debt0,
+        post_reserve1,
+        post_reserve0,
+        token1_ema_price_nad,
+        token1_directional_ema_price_nad,
+    )?;
+    let required_token0_for_debt1 = required_collateral_with_impact(
+        total_debt1,
+        post_reserve0,
+        post_reserve1,
+        token0_ema_price_nad,
+        token0_directional_ema_price_nad,
+    )?;
+
+    require!(
+        (post_reserve1 as u128) >= with_debt_coverage_buffer(required_token1_for_debt0)?,
+        ErrorCode::InsufficientPostWithdrawDebtCoverage
+    );
+    require!(
+        (post_reserve0 as u128) >= with_debt_coverage_buffer(required_token0_for_debt1)?,
+        ErrorCode::InsufficientPostWithdrawDebtCoverage
+    );
+
+    Ok(())
+}
+
+fn required_collateral_with_impact(
+    debt_amount: u64,
+    collateral_spot_reserve: u64,
+    debt_spot_reserve: u64,
+    collateral_ema_price_nad: u64,
+    collateral_directional_ema_price_nad: u64,
+) -> Result<u64> {
+    if debt_amount == 0 {
+        return Ok(0);
+    }
+
+    let (collateral_ema_reserve, debt_ema_reserve) =
+        construct_virtual_reserves_at_pessimistic_price(
+            collateral_spot_reserve,
+            debt_spot_reserve,
+            collateral_ema_price_nad,
+            collateral_directional_ema_price_nad,
+        )?;
+
+    require!(
+        collateral_ema_reserve > 0 && debt_ema_reserve > debt_amount,
+        ErrorCode::InsufficientPostWithdrawDebtCoverage
+    );
+
+    CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_amount)
+}
+
+fn with_debt_coverage_buffer(amount: u64) -> Result<u128> {
+    ceil_div(
+        (amount as u128)
+            .checked_mul(POST_WITHDRAW_DEBT_COVERAGE_BPS as u128)
+            .ok_or(ErrorCode::DebtMathOverflow)?,
+        BPS_DENOMINATOR as u128,
+    )
+    .ok_or(ErrorCode::DebtMathOverflow.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn liquidity_delta_withdrawal_solvency_passes_with_coverage_buffer() {
+        validate_post_withdraw_debt_coverage_with_prices(
+            1_000, 1_000, 100, 100, NAD, NAD, NAD, NAD,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn liquidity_delta_withdrawal_solvency_fails_without_coverage_buffer() {
+        let err = validate_post_withdraw_debt_coverage_with_prices(
+            1_000, 1_000, 900, 0, NAD, NAD, NAD, NAD,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
+    }
+
+    #[test]
+    fn liquidity_delta_withdrawal_solvency_fails_with_zero_pessimistic_price() {
+        let err = validate_post_withdraw_debt_coverage_with_prices(
+            1_000, 1_000, 100, 0, NAD, NAD, NAD, 0,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
+    }
+
+    #[test]
+    fn liquidity_delta_withdrawal_solvency_accounts_for_fee_remaining_in_reserves() {
+        let gross = 100_u64;
+        let fee = ceil_div(
+            (gross as u128) * (LIQUIDITY_WITHDRAWAL_FEE_BPS as u128),
+            BPS_DENOMINATOR as u128,
+        )
+        .unwrap() as u64;
+        let amount_out = gross - fee;
+
+        assert_eq!(fee, 1);
+        assert_eq!(amount_out, 99);
+        assert_eq!(1_000_u64 - amount_out, 901);
     }
 }

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -430,6 +430,11 @@ fn required_collateral_with_impact(
         return Ok(0);
     }
 
+    require!(
+        collateral_ema_price_nad > 0 && collateral_directional_ema_price_nad > 0,
+        ErrorCode::InsufficientPostWithdrawDebtCoverage
+    );
+
     let (collateral_ema_reserve, debt_ema_reserve) =
         construct_virtual_reserves_at_pessimistic_price(
             collateral_spot_reserve,

--- a/programs/omnipair/src/instructions/mod.rs
+++ b/programs/omnipair/src/instructions/mod.rs
@@ -8,6 +8,7 @@ pub use spot::*;
 pub use liquidity::*;
 pub use lending::common::*;
 pub use lending::add_collateral::*;
+pub use lending::borrow::*;
 pub use lending::liquidate::*;
 pub use lending::flashloan::*;
 pub use futarchy::*;

--- a/programs/omnipair/src/lib.rs
+++ b/programs/omnipair/src/lib.rs
@@ -121,10 +121,10 @@ pub mod omnipair {
 
     #[access_control(ctx.accounts.update_and_validate_remove(&args))]
     pub fn remove_liquidity(
-        ctx: Context<AdjustLiquidity>,
+        ctx: Context<RemoveLiquidity>,
         args: RemoveLiquidityArgs,
     ) -> Result<()> {
-        AdjustLiquidity::handle_remove(ctx, args)
+        RemoveLiquidity::handle_remove(ctx, args)
     }
 
     #[access_control(ctx.accounts.update_and_validate_swap(&args))]
@@ -147,8 +147,8 @@ pub mod omnipair {
     }
 
     #[access_control(ctx.accounts.update_and_validate_borrow(&args))]
-    pub fn borrow(ctx: Context<CommonAdjustDebt>, args: AdjustDebtArgs) -> Result<()> {
-        CommonAdjustDebt::handle_borrow(ctx, args)
+    pub fn borrow(ctx: Context<Borrow>, args: AdjustDebtArgs) -> Result<()> {
+        Borrow::handle_borrow(ctx, args)
     }
 
     #[access_control(ctx.accounts.update_and_validate_repay(&args))]

--- a/programs/omnipair/src/state/user_position.rs
+++ b/programs/omnipair/src/state/user_position.rs
@@ -78,6 +78,8 @@ impl UserPosition {
     /// With 10^6 scaling, the first borrow of 1 unit creates 1,000,000 shares,
     /// making subsequent rounding errors negligible (<0.0001% instead of potentially >10%).
     pub fn increase_debt(&mut self, pair: &mut Pair, debt_token: &Pubkey, amount: u64) -> Result<()> {
+        require!(amount > 0, ErrorCode::AmountZero);
+
         match *debt_token == pair.token0 {
             true => {
                 if pair.total_debt0_shares == 0 {
@@ -389,4 +391,61 @@ macro_rules! generate_user_position_seeds {
             &[$position.bump],
         ]
     };
-} 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::VaultBumps;
+
+    fn test_pair() -> Pair {
+        Pair::initialize(
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            6,
+            6,
+            Pubkey::new_unique(),
+            30,
+            60_000,
+            Some(8_000),
+            0,
+            [0; 32],
+            VERSION,
+            1,
+            VaultBumps::default(),
+            0,
+        )
+    }
+
+    fn test_position() -> UserPosition {
+        UserPosition {
+            owner: Pubkey::new_unique(),
+            pair: Pubkey::new_unique(),
+            collateral0_liquidation_cf_bps: 0,
+            collateral1_liquidation_cf_bps: 0,
+            collateral0: 0,
+            collateral1: 0,
+            debt0_shares: 0,
+            debt1_shares: 0,
+            bump: 1,
+        }
+    }
+
+    #[test]
+    fn increase_debt_rejects_zero_amount() {
+        let mut pair = test_pair();
+        pair.cash_reserve0 = 123;
+        let token0 = pair.token0;
+        let mut user_position = test_position();
+
+        let err = user_position
+            .increase_debt(&mut pair, &token0, 0)
+            .unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::AmountZero));
+        assert_eq!(pair.total_debt0, 0);
+        assert_eq!(pair.cash_reserve0, 123);
+        assert_eq!(user_position.debt0_shares, 0);
+    }
+}

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -77,7 +77,7 @@ pub fn construct_virtual_reserves_at_pessimistic_price(
     
     let pessimistic_price = min(collateral_directional_ema_price_nad, collateral_ema_price_nad) as u128;
     if pessimistic_price == 0 {
-        return Ok((collateral_spot_reserve, debt_spot_reserve));
+        return Ok((0, 0));
     }
 
     let spot_k = (collateral_spot_reserve as u128)
@@ -613,6 +613,14 @@ mod tests {
         let k_spot = x_spot as u128 * y_spot as u128;
         let k_virt = collateral_ema_reserve as u128 * debt_ema_reserve as u128;
         assert_eq!(k_spot, k_virt);
+    }
+
+    #[test]
+    fn zero_pessimistic_price_returns_zero_virtual_reserves() {
+        let (collateral_ema_reserve, debt_ema_reserve) =
+            construct_virtual_reserves_at_pessimistic_price(1_000, 1_000, NAD, 0).unwrap();
+
+        assert_eq!((collateral_ema_reserve, debt_ema_reserve), (0, 0));
     }
 
     #[test]

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -77,7 +77,7 @@ pub fn construct_virtual_reserves_at_pessimistic_price(
     
     let pessimistic_price = min(collateral_directional_ema_price_nad, collateral_ema_price_nad) as u128;
     if pessimistic_price == 0 {
-        return Ok((0, 0));
+        return Ok((collateral_spot_reserve, debt_spot_reserve));
     }
 
     let spot_k = (collateral_spot_reserve as u128)
@@ -613,14 +613,6 @@ mod tests {
         let k_spot = x_spot as u128 * y_spot as u128;
         let k_virt = collateral_ema_reserve as u128 * debt_ema_reserve as u128;
         assert_eq!(k_spot, k_virt);
-    }
-
-    #[test]
-    fn zero_pessimistic_price_returns_zero_virtual_reserves() {
-        let (collateral_ema_reserve, debt_ema_reserve) =
-            construct_virtual_reserves_at_pessimistic_price(1_000, 1_000, NAD, 0).unwrap();
-
-        assert_eq!((collateral_ema_reserve, debt_ema_reserve), (0, 0));
     }
 
     #[test]

--- a/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
+++ b/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
@@ -155,6 +155,7 @@ mod tests {
     use super::*;
     use anchor_lang::solana_program::{
         account_info::AccountInfo,
+        hash::hash,
         instruction::AccountMeta,
         sysvar::instructions::{
             construct_instructions_data, store_current_index, BorrowedAccountMeta,
@@ -209,6 +210,23 @@ mod tests {
         );
 
         require_no_matching_liquidity_delta(pair, &account_info, include_remove_liquidity)
+    }
+
+    fn anchor_global_discriminator(name: &str) -> [u8; 8] {
+        let digest = hash(format!("global:{name}").as_bytes()).to_bytes();
+        digest[..8].try_into().unwrap()
+    }
+
+    #[test]
+    fn liquidity_delta_discriminators_match_anchor_instruction_names() {
+        assert_eq!(
+            ADD_LIQUIDITY_DISCRIMINATOR,
+            anchor_global_discriminator("add_liquidity")
+        );
+        assert_eq!(
+            REMOVE_LIQUIDITY_DISCRIMINATOR,
+            anchor_global_discriminator("remove_liquidity")
+        );
     }
 
     #[test]

--- a/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
+++ b/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
@@ -1,0 +1,357 @@
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{
+    instruction::Instruction,
+    sysvar,
+    sysvar::instructions::{load_current_index_checked, load_instruction_at_checked},
+};
+
+use crate::errors::ErrorCode;
+
+const ADD_LIQUIDITY_DISCRIMINATOR: [u8; 8] = [0xb5, 0x9d, 0x59, 0x43, 0x8f, 0xb6, 0x34, 0x48];
+const REMOVE_LIQUIDITY_DISCRIMINATOR: [u8; 8] = [0x50, 0x55, 0xd1, 0x48, 0x18, 0xce, 0xb1, 0x6c];
+
+#[derive(Clone, Copy)]
+pub enum LiquidityDeltaInstruction {
+    AddLiquidity,
+    RemoveLiquidity,
+}
+
+pub fn require_top_level_liquidity_delta_ix(
+    pair: &Pubkey,
+    instructions_sysvar: &AccountInfo,
+    expected_instruction: LiquidityDeltaInstruction,
+) -> Result<()> {
+    require_keys_eq!(
+        *instructions_sysvar.key,
+        sysvar::instructions::ID,
+        ErrorCode::InvalidInstructionsSysvar
+    );
+
+    let current_index = load_current_index_checked(instructions_sysvar)
+        .map_err(|_| error!(ErrorCode::InvalidInstructionsSysvar))?
+        as usize;
+    let current_instruction = load_instruction_at_checked(current_index, instructions_sysvar)
+        .map_err(|_| error!(ErrorCode::InvalidInstructionsSysvar))?;
+
+    require!(
+        is_expected_same_pair_liquidity_delta(&current_instruction, pair, expected_instruction),
+        ErrorCode::LiquidityDeltaCircuitBreakerCpi
+    );
+    Ok(())
+}
+
+pub fn require_no_same_tx_liquidity_delta(
+    pair: &Pubkey,
+    instructions_sysvar: &AccountInfo,
+) -> Result<()> {
+    require_no_matching_liquidity_delta(pair, instructions_sysvar, true)
+}
+
+pub fn require_no_same_tx_add_liquidity(
+    pair: &Pubkey,
+    instructions_sysvar: &AccountInfo,
+) -> Result<()> {
+    require_no_matching_liquidity_delta(pair, instructions_sysvar, false)
+}
+
+fn require_no_matching_liquidity_delta(
+    pair: &Pubkey,
+    instructions_sysvar: &AccountInfo,
+    include_remove_liquidity: bool,
+) -> Result<()> {
+    require_keys_eq!(
+        *instructions_sysvar.key,
+        sysvar::instructions::ID,
+        ErrorCode::InvalidInstructionsSysvar
+    );
+
+    let instruction_count = load_instruction_count(instructions_sysvar)?;
+
+    for index in 0..instruction_count {
+        let instruction = load_instruction_at_checked(index, instructions_sysvar)
+            .map_err(|_| error!(ErrorCode::InvalidInstructionsSysvar))?;
+
+        if is_same_pair_liquidity_delta(&instruction, pair, include_remove_liquidity) {
+            return err!(ErrorCode::LiquidityDeltaCircuitBreaker);
+        }
+    }
+
+    Ok(())
+}
+
+fn load_instruction_count(instructions_sysvar: &AccountInfo) -> Result<usize> {
+    let data = instructions_sysvar
+        .try_borrow_data()
+        .map_err(|_| error!(ErrorCode::InvalidInstructionsSysvar))?;
+    require!(data.len() >= 2, ErrorCode::InvalidInstructionsSysvar);
+    Ok(u16::from_le_bytes([data[0], data[1]]) as usize)
+}
+
+fn is_same_pair_liquidity_delta(
+    instruction: &Instruction,
+    pair: &Pubkey,
+    include_remove_liquidity: bool,
+) -> bool {
+    if instruction.program_id != crate::ID {
+        return false;
+    }
+
+    let Some(discriminator) = instruction.data.get(..8) else {
+        return false;
+    };
+
+    let is_liquidity_delta =
+        discriminator_matches(discriminator, LiquidityDeltaInstruction::AddLiquidity)
+            || (include_remove_liquidity && discriminator == REMOVE_LIQUIDITY_DISCRIMINATOR);
+    if !is_liquidity_delta {
+        return false;
+    }
+
+    instruction
+        .accounts
+        .first()
+        .map(|account| account.pubkey == *pair)
+        .unwrap_or(false)
+}
+
+fn is_expected_same_pair_liquidity_delta(
+    instruction: &Instruction,
+    pair: &Pubkey,
+    expected_instruction: LiquidityDeltaInstruction,
+) -> bool {
+    if instruction.program_id != crate::ID {
+        return false;
+    }
+
+    let Some(discriminator) = instruction.data.get(..8) else {
+        return false;
+    };
+
+    if !discriminator_matches(discriminator, expected_instruction) {
+        return false;
+    }
+
+    instruction
+        .accounts
+        .first()
+        .map(|account| account.pubkey == *pair)
+        .unwrap_or(false)
+}
+
+fn discriminator_matches(
+    discriminator: &[u8],
+    expected_instruction: LiquidityDeltaInstruction,
+) -> bool {
+    match expected_instruction {
+        LiquidityDeltaInstruction::AddLiquidity => discriminator == ADD_LIQUIDITY_DISCRIMINATOR,
+        LiquidityDeltaInstruction::RemoveLiquidity => {
+            discriminator == REMOVE_LIQUIDITY_DISCRIMINATOR
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anchor_lang::solana_program::{
+        account_info::AccountInfo,
+        instruction::AccountMeta,
+        sysvar::instructions::{
+            construct_instructions_data, store_current_index, BorrowedAccountMeta,
+            BorrowedInstruction,
+        },
+    };
+
+    fn borrowed_instruction<'a>(
+        program_id: &'a Pubkey,
+        pair: &'a Pubkey,
+        data: &'a [u8],
+    ) -> BorrowedInstruction<'a> {
+        BorrowedInstruction {
+            program_id,
+            accounts: vec![BorrowedAccountMeta {
+                pubkey: pair,
+                is_signer: false,
+                is_writable: true,
+            }],
+            data,
+        }
+    }
+
+    fn unrelated_instruction(program_id: Pubkey) -> Instruction {
+        Instruction {
+            program_id,
+            accounts: vec![AccountMeta::new(Pubkey::new_unique(), false)],
+            data: vec![1, 2, 3],
+        }
+    }
+
+    fn run_guard(
+        pair: &Pubkey,
+        instructions: &[BorrowedInstruction],
+        current_index: u16,
+        include_remove_liquidity: bool,
+    ) -> Result<()> {
+        let key = sysvar::instructions::ID;
+        let owner = sysvar::ID;
+        let mut lamports = 0;
+        let mut data = construct_instructions_data(instructions);
+        store_current_index(&mut data, current_index);
+        let account_info = AccountInfo::new(
+            &key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+
+        require_no_matching_liquidity_delta(pair, &account_info, include_remove_liquidity)
+    }
+
+    #[test]
+    fn liquidity_delta_blocks_same_pair_add_liquidity() {
+        let pair = Pubkey::new_unique();
+        let current_pair = Pubkey::new_unique();
+        let add_ix = borrowed_instruction(&crate::ID, &pair, &ADD_LIQUIDITY_DISCRIMINATOR);
+        let current_ix = borrowed_instruction(&crate::ID, &current_pair, &[9; 8]);
+
+        let err = run_guard(&pair, &[add_ix, current_ix], 1, true).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreaker));
+    }
+
+    #[test]
+    fn liquidity_delta_blocks_same_pair_remove_liquidity() {
+        let pair = Pubkey::new_unique();
+        let current_pair = Pubkey::new_unique();
+        let remove_ix = borrowed_instruction(&crate::ID, &pair, &REMOVE_LIQUIDITY_DISCRIMINATOR);
+        let current_ix = borrowed_instruction(&crate::ID, &current_pair, &[9; 8]);
+
+        let err = run_guard(&pair, &[remove_ix, current_ix], 1, true).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreaker));
+    }
+
+    #[test]
+    fn liquidity_delta_blocks_current_top_level_add_liquidity() {
+        let pair = Pubkey::new_unique();
+        let add_ix = borrowed_instruction(&crate::ID, &pair, &ADD_LIQUIDITY_DISCRIMINATOR);
+
+        let err = run_guard(&pair, &[add_ix], 0, true).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreaker));
+    }
+
+    #[test]
+    fn liquidity_delta_blocks_current_top_level_remove_liquidity() {
+        let pair = Pubkey::new_unique();
+        let remove_ix = borrowed_instruction(&crate::ID, &pair, &REMOVE_LIQUIDITY_DISCRIMINATOR);
+
+        let err = run_guard(&pair, &[remove_ix], 0, true).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreaker));
+    }
+
+    #[test]
+    fn add_only_guard_allows_remove_liquidity() {
+        let pair = Pubkey::new_unique();
+        let current_pair = Pubkey::new_unique();
+        let remove_ix = borrowed_instruction(&crate::ID, &pair, &REMOVE_LIQUIDITY_DISCRIMINATOR);
+        let current_ix = borrowed_instruction(&crate::ID, &current_pair, &[9; 8]);
+
+        run_guard(&pair, &[remove_ix, current_ix], 1, false).unwrap();
+    }
+
+    #[test]
+    fn liquidity_delta_allows_different_pair() {
+        let pair = Pubkey::new_unique();
+        let other_pair = Pubkey::new_unique();
+        let current_pair = Pubkey::new_unique();
+        let add_ix = borrowed_instruction(&crate::ID, &other_pair, &ADD_LIQUIDITY_DISCRIMINATOR);
+        let current_ix = borrowed_instruction(&crate::ID, &current_pair, &[9; 8]);
+
+        run_guard(&pair, &[add_ix, current_ix], 1, true).unwrap();
+    }
+
+    #[test]
+    fn liquidity_delta_allows_unrelated_instruction() {
+        let pair = Pubkey::new_unique();
+        let current_pair = Pubkey::new_unique();
+        let unrelated = unrelated_instruction(Pubkey::new_unique());
+        let current_ix = borrowed_instruction(&crate::ID, &current_pair, &[9; 8]);
+        let borrowed_unrelated = BorrowedInstruction {
+            program_id: &unrelated.program_id,
+            accounts: unrelated
+                .accounts
+                .iter()
+                .map(|account| BorrowedAccountMeta {
+                    pubkey: &account.pubkey,
+                    is_signer: account.is_signer,
+                    is_writable: account.is_writable,
+                })
+                .collect(),
+            data: &unrelated.data,
+        };
+
+        run_guard(&pair, &[borrowed_unrelated, current_ix], 1, true).unwrap();
+    }
+
+    #[test]
+    fn top_level_liquidity_delta_requires_current_ix_match() {
+        let pair = Pubkey::new_unique();
+        let other_program = Pubkey::new_unique();
+        let add_ix = borrowed_instruction(&crate::ID, &pair, &ADD_LIQUIDITY_DISCRIMINATOR);
+        let other_ix = borrowed_instruction(&other_program, &pair, &[9; 8]);
+        let key = sysvar::instructions::ID;
+        let owner = sysvar::ID;
+        let mut lamports = 0;
+        let mut data = construct_instructions_data(&[other_ix, add_ix]);
+        store_current_index(&mut data, 1);
+        let account_info = AccountInfo::new(
+            &key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+
+        require_top_level_liquidity_delta_ix(
+            &pair,
+            &account_info,
+            LiquidityDeltaInstruction::AddLiquidity,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn top_level_liquidity_delta_rejects_wrapper_current_ix() {
+        let pair = Pubkey::new_unique();
+        let wrapper_program = Pubkey::new_unique();
+        let wrapper_ix = borrowed_instruction(&wrapper_program, &pair, &[9; 8]);
+        let key = sysvar::instructions::ID;
+        let owner = sysvar::ID;
+        let mut lamports = 0;
+        let mut data = construct_instructions_data(&[wrapper_ix]);
+        store_current_index(&mut data, 0);
+        let account_info = AccountInfo::new(
+            &key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+
+        let err = require_top_level_liquidity_delta_ix(
+            &pair,
+            &account_info,
+            LiquidityDeltaInstruction::AddLiquidity,
+        )
+        .unwrap_err();
+        assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreakerCpi));
+    }
+}

--- a/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
+++ b/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
@@ -40,6 +40,28 @@ pub fn require_top_level_liquidity_delta_ix(
     Ok(())
 }
 
+pub fn require_current_ix_is_final(instructions_sysvar: &AccountInfo) -> Result<()> {
+    require_keys_eq!(
+        *instructions_sysvar.key,
+        sysvar::instructions::ID,
+        ErrorCode::InvalidInstructionsSysvar
+    );
+
+    let current_index = load_current_index_checked(instructions_sysvar)
+        .map_err(|_| error!(ErrorCode::InvalidInstructionsSysvar))?
+        as usize;
+    let instruction_count = load_instruction_count(instructions_sysvar)?;
+
+    require!(
+        current_index
+            .checked_add(1)
+            .ok_or(ErrorCode::InvalidInstructionsSysvar)?
+            == instruction_count,
+        ErrorCode::LiquidityDeltaCircuitBreaker
+    );
+    Ok(())
+}
+
 pub fn require_no_same_tx_liquidity_delta(
     pair: &Pubkey,
     instructions_sysvar: &AccountInfo,
@@ -371,5 +393,56 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreakerCpi));
+    }
+
+    #[test]
+    fn current_ix_final_allows_last_top_level_ix() {
+        let pair = Pubkey::new_unique();
+        let first_program = Pubkey::new_unique();
+        let first_ix = borrowed_instruction(&first_program, &pair, &[9; 8]);
+        let remove_ix = borrowed_instruction(&crate::ID, &pair, &REMOVE_LIQUIDITY_DISCRIMINATOR);
+        let key = sysvar::instructions::ID;
+        let owner = sysvar::ID;
+        let mut lamports = 0;
+        let mut data = construct_instructions_data(&[first_ix, remove_ix]);
+        store_current_index(&mut data, 1);
+        let account_info = AccountInfo::new(
+            &key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+
+        require_current_ix_is_final(&account_info).unwrap();
+    }
+
+    #[test]
+    fn current_ix_final_rejects_following_top_level_ix() {
+        let pair = Pubkey::new_unique();
+        let remove_ix = borrowed_instruction(&crate::ID, &pair, &REMOVE_LIQUIDITY_DISCRIMINATOR);
+        let following_program = Pubkey::new_unique();
+        let following_ix = borrowed_instruction(&following_program, &pair, &[9; 8]);
+        let key = sysvar::instructions::ID;
+        let owner = sysvar::ID;
+        let mut lamports = 0;
+        let mut data = construct_instructions_data(&[remove_ix, following_ix]);
+        store_current_index(&mut data, 0);
+        let account_info = AccountInfo::new(
+            &key,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+
+        let err = require_current_ix_is_final(&account_info).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreaker));
     }
 }

--- a/programs/omnipair/src/utils/mod.rs
+++ b/programs/omnipair/src/utils/mod.rs
@@ -6,3 +6,4 @@ pub mod math;
 pub mod account;
 pub mod token;
 pub mod gamm_math;
+pub mod liquidity_delta_circuit_breaker;


### PR DESCRIPTION
## Summary
- add a liquidity delta circuit breaker that scans the instructions sysvar for same-pair add/remove liquidity
- require top-level invocation for add/remove liquidity and block same-tx liquidity deltas from borrow/remove-collateral
- add post-withdraw debt coverage validation using net withdrawal amounts, so the 1% withdrawal fee remains in reserves

## Verification
- cargo test -p omnipair liquidity_delta --lib
- cargo check -p omnipair
- anchor build

Notes: anchor build still reports the existing stack-offset and undefined syscall warnings seen before this change.