### PR TITLE
fix(omnipair): allow post-withdraw cleanup instructions

### DIFF
--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -13,8 +13,8 @@ use crate::generate_gamm_pair_seeds;
 use crate::state::{futarchy_authority::FutarchyAuthority, pair::Pair, rate_model::RateModel};
 use crate::utils::gamm_math::{construct_virtual_reserves_at_pessimistic_price, CPCurve};
 use crate::utils::liquidity_delta_circuit_breaker::{
-    require_current_ix_is_final, require_no_same_tx_add_liquidity,
-    require_top_level_liquidity_delta_ix, LiquidityDeltaInstruction,
+    require_no_same_tx_add_liquidity, require_top_level_liquidity_delta_ix,
+    LiquidityDeltaInstruction,
 };
 use crate::utils::math::ceil_div;
 use crate::utils::token::{token_burn, transfer_from_vault_to_user};
@@ -133,7 +133,6 @@ impl<'info> RemoveLiquidity<'info> {
             &self.instructions_sysvar.to_account_info(),
             LiquidityDeltaInstruction::RemoveLiquidity,
         )?;
-        require_current_ix_is_final(&self.instructions_sysvar.to_account_info())?;
         require_no_same_tx_add_liquidity(
             &self.pair.key(),
             &self.instructions_sysvar.to_account_info(),

--- a/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
+++ b/programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
@@ -40,28 +40,6 @@ pub fn require_top_level_liquidity_delta_ix(
     Ok(())
 }
 
-pub fn require_current_ix_is_final(instructions_sysvar: &AccountInfo) -> Result<()> {
-    require_keys_eq!(
-        *instructions_sysvar.key,
-        sysvar::instructions::ID,
-        ErrorCode::InvalidInstructionsSysvar
-    );
-
-    let current_index = load_current_index_checked(instructions_sysvar)
-        .map_err(|_| error!(ErrorCode::InvalidInstructionsSysvar))?
-        as usize;
-    let instruction_count = load_instruction_count(instructions_sysvar)?;
-
-    require!(
-        current_index
-            .checked_add(1)
-            .ok_or(ErrorCode::InvalidInstructionsSysvar)?
-            == instruction_count,
-        ErrorCode::LiquidityDeltaCircuitBreaker
-    );
-    Ok(())
-}
-
 pub fn require_no_same_tx_liquidity_delta(
     pair: &Pubkey,
     instructions_sysvar: &AccountInfo,
@@ -396,32 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn current_ix_final_allows_last_top_level_ix() {
-        let pair = Pubkey::new_unique();
-        let first_program = Pubkey::new_unique();
-        let first_ix = borrowed_instruction(&first_program, &pair, &[9; 8]);
-        let remove_ix = borrowed_instruction(&crate::ID, &pair, &REMOVE_LIQUIDITY_DISCRIMINATOR);
-        let key = sysvar::instructions::ID;
-        let owner = sysvar::ID;
-        let mut lamports = 0;
-        let mut data = construct_instructions_data(&[first_ix, remove_ix]);
-        store_current_index(&mut data, 1);
-        let account_info = AccountInfo::new(
-            &key,
-            false,
-            false,
-            &mut lamports,
-            &mut data,
-            &owner,
-            false,
-            0,
-        );
-
-        require_current_ix_is_final(&account_info).unwrap();
-    }
-
-    #[test]
-    fn current_ix_final_rejects_following_top_level_ix() {
+    fn top_level_liquidity_delta_allows_following_sibling_ix() {
         let pair = Pubkey::new_unique();
         let remove_ix = borrowed_instruction(&crate::ID, &pair, &REMOVE_LIQUIDITY_DISCRIMINATOR);
         let following_program = Pubkey::new_unique();
@@ -442,7 +395,11 @@ mod tests {
             0,
         );
 
-        let err = require_current_ix_is_final(&account_info).unwrap_err();
-        assert_eq!(err, error!(ErrorCode::LiquidityDeltaCircuitBreaker));
+        require_top_level_liquidity_delta_ix(
+            &pair,
+            &account_info,
+            LiquidityDeltaInstruction::RemoveLiquidity,
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- remove the terminal/final-instruction requirement from remove_liquidity
- keep remove_liquidity top-level and keep the same-pair add_liquidity same-transaction guard
- replace the terminal-guard tests with a regression proving top-level liquidity deltas may have harmless sibling instructions

## Rationale
The terminal guard was an over-broad response to the swap-after-withdrawal V12 invariant finding. It blocks normal frontend cleanup flows like closing wrapped SOL accounts after withdrawal. This PR restores transaction composability while preserving the original liquidity-delta protections from PR #84.

## Verification
- cargo test -p omnipair liquidity_delta
- cargo check -p omnipair
- rustfmt --check programs/omnipair/src/instructions/liquidity/remove_liquidity.rs programs/omnipair/src/utils/liquidity_delta_circuit_breaker.rs
- git diff --check