### PR TITLE
OMFG-986 Add swap event in liquidation ixn

### DIFF
--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -10,7 +10,7 @@ use crate::{
     state::futarchy_authority::FutarchyAuthority,
     constants::*,
     errors::ErrorCode,
-    events::{AdjustDebtEvent, EventMetadata, UserPositionLiquidatedEvent, UserPositionUpdatedEvent},
+    events::{AdjustDebtEvent, EventMetadata, SwapEvent, UserPositionLiquidatedEvent, UserPositionUpdatedEvent},
     state::user_position::{UserPosition, DebtDecreaseReason},
     utils::{
         token::{transfer_from_vault_to_user, transfer_from_vault_to_vault}, 
@@ -357,6 +357,18 @@ impl<'info> Liquidate<'info> {
                 pair.cash_reserve1 = pair.cash_reserve1.saturating_add(collateral_to_reserves);
             }
         }
+
+        emit_cpi!(SwapEvent {
+            metadata: EventMetadata::new(payer.key(), pair.key()),
+            reserve0: pair.reserve0,
+            reserve1: pair.reserve1,
+            is_token0_in: is_collateral_token0,
+            amount_in: collateral_to_reserves,
+            amount_out: debt_to_writeoff,
+            amount_in_after_fee: collateral_to_reserves,
+            lp_fee: 0,
+            protocol_fee: 0,
+        });
 
         // Emit debt adjustment event (debt written off)
         let (amount0, amount1) = if is_collateral_token0 {


### PR DESCRIPTION
## Summary

- Emits the existing `SwapEvent` from the liquidation instruction after liquidation reserve state is finalized.
- Reports collateral added to reserves as swap input and written-off debt as output.
- Keeps the liquidation-emitted swap event fee-neutral (`amount_in_after_fee == amount_in`, `lp_fee: 0`, `protocol_fee: 0`) so liquidation fee/revenue analytics continue to come from liquidation events without double counting.

Jira: [OMFG-986](https://omnipair.atlassian.net/browse/OMFG-986)

## Stacked follow-up

- #93 is stacked on this branch and lowers the current V1 LP withdrawal post-withdraw debt coverage requirement from 115% to 100%.
- Intended merge order: merge #93 into this branch, then merge this PR into `main`.

## Validation

- `cargo check -p omnipair --features no-entrypoint` passed.
- `cargo check -p omnipair --features no-entrypoint --locked` is blocked on latest `main` because `Cargo.lock` has a stale `omnipair` package version (`0.9.9` vs `0.10.4`).
- `cargo test -p omnipair --features no-entrypoint` compiled and ran, but existing tests failed outside this change: rate model tests and `utils::gamm_math::tests::manipulation_bounded_by_ema`.

[OMFG-986]: https://omnipair.atlassian.net/browse/OMFG-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
