### PR TITLE
Reduce withdrawal debt coverage to 100%

### DIFF
--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -23,7 +23,7 @@ pub const LIQUIDATION_PENALTY_BPS: u16 = 300; // 3% total liquidation penalty (0
 #[constant]
 pub const LIQUIDITY_WITHDRAWAL_FEE_BPS: u16 = 100; // 1% fee on liquidity withdrawal (goes to remaining LPs)
 #[constant]
-pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 11_500; // 115% debt coverage required after liquidity withdrawal
+pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 10_000; // 100% debt coverage required after liquidity withdrawal
 #[constant]
 pub const PAIR_CREATION_FEE_LAMPORTS: u64 = 200_000_000; // 0.2 SOL
 // 3log2(100) = 19.93 secs (with 400ms slot time, this is ~50 slots)

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -408,11 +408,11 @@ fn validate_post_withdraw_debt_coverage_with_prices(
     )?;
 
     require!(
-        (post_reserve1 as u128) >= with_debt_coverage_buffer(required_token1_for_debt0)?,
+        (post_reserve1 as u128) >= with_required_debt_coverage(required_token1_for_debt0)?,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
     require!(
-        (post_reserve0 as u128) >= with_debt_coverage_buffer(required_token0_for_debt1)?,
+        (post_reserve0 as u128) >= with_required_debt_coverage(required_token0_for_debt1)?,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
 
@@ -451,7 +451,7 @@ fn required_collateral_with_impact(
     CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_amount)
 }
 
-fn with_debt_coverage_buffer(amount: u64) -> Result<u128> {
+fn with_required_debt_coverage(amount: u64) -> Result<u128> {
     ceil_div(
         (amount as u128)
             .checked_mul(POST_WITHDRAW_DEBT_COVERAGE_BPS as u128)
@@ -466,7 +466,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_passes_with_coverage_buffer() {
+    fn liquidity_delta_withdrawal_solvency_passes_with_required_coverage() {
         validate_post_withdraw_debt_coverage_with_prices(
             1_000, 1_000, 100, 100, NAD, NAD, NAD, NAD,
         )
@@ -474,7 +474,15 @@ mod tests {
     }
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_fails_without_coverage_buffer() {
+    fn liquidity_delta_withdrawal_solvency_accepts_exact_debt_coverage() {
+        validate_post_withdraw_debt_coverage_with_prices(
+            1_000, 1_000, 500, 0, NAD, NAD, NAD, NAD,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn liquidity_delta_withdrawal_solvency_fails_without_required_coverage() {
         let err = validate_post_withdraw_debt_coverage_with_prices(
             1_000, 1_000, 900, 0, NAD, NAD, NAD, NAD,
         )


### PR DESCRIPTION
## Stack

- Stacked on #91 (`feat/OMFG-986-liquidation-swap-event`), which targets `main`.
- Intended merge order: merge this PR into the #91 branch, then merge #91 into `main`.

## Summary

- Lower the current V1 liquidity withdrawal post-withdraw debt coverage requirement from 115% to 100%.
- Rename the internal helper/test wording from "coverage buffer" to "required coverage" now that the requirement is exact coverage.
- Add a focused regression test for an exactly covered post-withdraw state that should now pass.

## Why

The 115% post-withdraw debt coverage circuit breaker can reject larger LP liquidity removals even when debt remains fully covered under the pessimistic constant-product impact calculation. This change keeps the post-withdraw solvency requirement, but removes the extra 15% haircut.

## Important scope note

This does **not** fix `InstructionError Custom 6021`. In the current IDL, `6021` is `InsufficientCashReserve1`, meaning the requested token1 transfer exceeds accounted token1 cash. For STORE/USDC, token1 is USDC, so remove-all or other large withdrawals can fail before the debt-coverage check. That should be handled with a cash-aware withdraw cap in the client/API path.

## Validation

- `cargo test -p omnipair liquidity_delta_withdrawal_solvency -- --nocapture`
