### PR TITLE
feat: rework internal liquidations and add borrow position transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "omnipair"
-version = "0.9.9"
+version = "0.10.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,6 +2364,7 @@ dependencies = [
  "rand 0.8.5",
  "solana-security-txt",
  "spl-math",
+ "spl-memo",
  "spl-token 4.0.2",
  "spl-token-2022",
  "uint 0.9.5",

--- a/decoders/omnipair-decoder/src/instructions/liquidate.rs
+++ b/decoders/omnipair-decoder/src/instructions/liquidate.rs
@@ -1,12 +1,10 @@
+use carbon_core::{account_utils::next_account, borsh, CarbonDeserialize};
 
-
-use carbon_core::{CarbonDeserialize, borsh, account_utils::next_account};
-
-
-#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash)]
+#[derive(
+    CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash,
+)]
 #[carbon(discriminator = "0xdfb3e27d302e274a")]
-pub struct Liquidate{
-}
+pub struct Liquidate {}
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct LiquidateInstructionAccounts {
@@ -17,7 +15,10 @@ pub struct LiquidateInstructionAccounts {
     pub collateral_vault: solana_pubkey::Pubkey,
     pub caller_token_account: solana_pubkey::Pubkey,
     pub collateral_token_mint: solana_pubkey::Pubkey,
-    pub reserve_vault: solana_pubkey::Pubkey,
+    pub debt_token_mint: solana_pubkey::Pubkey,
+    pub debt_reserve_vault: solana_pubkey::Pubkey,
+    pub liquidator_debt_token_account: solana_pubkey::Pubkey,
+    pub collateral_reserve_vault: solana_pubkey::Pubkey,
     pub position_owner: solana_pubkey::Pubkey,
     pub payer: solana_pubkey::Pubkey,
     pub token_program: solana_pubkey::Pubkey,
@@ -30,7 +31,9 @@ pub struct LiquidateInstructionAccounts {
 impl carbon_core::deserialize::ArrangeAccounts for Liquidate {
     type ArrangedAccounts = LiquidateInstructionAccounts;
 
-    fn arrange_accounts(accounts: &[solana_instruction::AccountMeta]) -> Option<Self::ArrangedAccounts> {
+    fn arrange_accounts(
+        accounts: &[solana_instruction::AccountMeta],
+    ) -> Option<Self::ArrangedAccounts> {
         let mut iter = accounts.iter();
         let pair = next_account(&mut iter)?;
         let user_position = next_account(&mut iter)?;
@@ -39,7 +42,10 @@ impl carbon_core::deserialize::ArrangeAccounts for Liquidate {
         let collateral_vault = next_account(&mut iter)?;
         let caller_token_account = next_account(&mut iter)?;
         let collateral_token_mint = next_account(&mut iter)?;
-        let reserve_vault = next_account(&mut iter)?;
+        let debt_token_mint = next_account(&mut iter)?;
+        let debt_reserve_vault = next_account(&mut iter)?;
+        let liquidator_debt_token_account = next_account(&mut iter)?;
+        let collateral_reserve_vault = next_account(&mut iter)?;
         let position_owner = next_account(&mut iter)?;
         let payer = next_account(&mut iter)?;
         let token_program = next_account(&mut iter)?;
@@ -56,7 +62,10 @@ impl carbon_core::deserialize::ArrangeAccounts for Liquidate {
             collateral_vault,
             caller_token_account,
             collateral_token_mint,
-            reserve_vault,
+            debt_token_mint,
+            debt_reserve_vault,
+            liquidator_debt_token_account,
+            collateral_reserve_vault,
             position_owner,
             payer,
             token_program,

--- a/decoders/omnipair-decoder/src/instructions/mod.rs
+++ b/decoders/omnipair-decoder/src/instructions/mod.rs
@@ -17,6 +17,7 @@ pub mod repay;
 pub mod set_global_reduce_only;
 pub mod set_pair_reduce_only;
 pub mod swap;
+pub mod transfer_user_position;
 pub mod update_futarchy_authority;
 pub mod update_protocol_revenue;
 pub mod update_revenue_recipients;
@@ -35,6 +36,7 @@ pub mod update_pair_event;
 pub mod user_liquidity_position_updated_event;
 pub mod user_position_created_event;
 pub mod user_position_liquidated_event;
+pub mod user_position_transferred_event;
 pub mod user_position_updated_event;
 
 #[derive(carbon_core::InstructionType, serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone, Hash)]
@@ -53,6 +55,7 @@ pub enum OmnipairInstruction {
     SetGlobalReduceOnly(set_global_reduce_only::SetGlobalReduceOnly),
     SetPairReduceOnly(set_pair_reduce_only::SetPairReduceOnly),
     Swap(swap::Swap),
+    TransferUserPosition(transfer_user_position::TransferUserPosition),
     UpdateFutarchyAuthority(update_futarchy_authority::UpdateFutarchyAuthority),
     UpdateProtocolRevenue(update_protocol_revenue::UpdateProtocolRevenue),
     UpdateRevenueRecipients(update_revenue_recipients::UpdateRevenueRecipients),
@@ -71,6 +74,7 @@ pub enum OmnipairInstruction {
     UserLiquidityPositionUpdatedEvent(user_liquidity_position_updated_event::UserLiquidityPositionUpdatedEvent),
     UserPositionCreatedEvent(user_position_created_event::UserPositionCreatedEvent),
     UserPositionLiquidatedEvent(user_position_liquidated_event::UserPositionLiquidatedEvent),
+    UserPositionTransferredEvent(user_position_transferred_event::UserPositionTransferredEvent),
     UserPositionUpdatedEvent(user_position_updated_event::UserPositionUpdatedEvent),
 }
 
@@ -96,6 +100,7 @@ impl<'a> carbon_core::instruction::InstructionDecoder<'a> for OmnipairDecoder {
             OmnipairInstruction::SetGlobalReduceOnly => set_global_reduce_only::SetGlobalReduceOnly,
             OmnipairInstruction::SetPairReduceOnly => set_pair_reduce_only::SetPairReduceOnly,
             OmnipairInstruction::Swap => swap::Swap,
+            OmnipairInstruction::TransferUserPosition => transfer_user_position::TransferUserPosition,
             OmnipairInstruction::UpdateFutarchyAuthority => update_futarchy_authority::UpdateFutarchyAuthority,
             OmnipairInstruction::UpdateProtocolRevenue => update_protocol_revenue::UpdateProtocolRevenue,
             OmnipairInstruction::UpdateRevenueRecipients => update_revenue_recipients::UpdateRevenueRecipients,
@@ -114,6 +119,7 @@ impl<'a> carbon_core::instruction::InstructionDecoder<'a> for OmnipairDecoder {
             OmnipairInstruction::UserLiquidityPositionUpdatedEvent => user_liquidity_position_updated_event::UserLiquidityPositionUpdatedEvent,
             OmnipairInstruction::UserPositionCreatedEvent => user_position_created_event::UserPositionCreatedEvent,
             OmnipairInstruction::UserPositionLiquidatedEvent => user_position_liquidated_event::UserPositionLiquidatedEvent,
+            OmnipairInstruction::UserPositionTransferredEvent => user_position_transferred_event::UserPositionTransferredEvent,
             OmnipairInstruction::UserPositionUpdatedEvent => user_position_updated_event::UserPositionUpdatedEvent,
         )
     }

--- a/decoders/omnipair-decoder/src/instructions/transfer_user_position.rs
+++ b/decoders/omnipair-decoder/src/instructions/transfer_user_position.rs
@@ -1,0 +1,46 @@
+
+use carbon_core::{CarbonDeserialize, account_utils::next_account, borsh};
+
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash)]
+#[carbon(discriminator = "0x8a02d9c7d2229294")]
+pub struct TransferUserPosition;
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
+pub struct TransferUserPositionInstructionAccounts {
+    pub pair: solana_pubkey::Pubkey,
+    pub from_position: solana_pubkey::Pubkey,
+    pub to_position: solana_pubkey::Pubkey,
+    pub current_owner: solana_pubkey::Pubkey,
+    pub new_owner: solana_pubkey::Pubkey,
+    pub system_program: solana_pubkey::Pubkey,
+    pub event_authority: solana_pubkey::Pubkey,
+    pub program: solana_pubkey::Pubkey,
+}
+
+impl carbon_core::deserialize::ArrangeAccounts for TransferUserPosition {
+    type ArrangedAccounts = TransferUserPositionInstructionAccounts;
+
+    fn arrange_accounts(accounts: &[solana_instruction::AccountMeta]) -> Option<Self::ArrangedAccounts> {
+        let mut iter = accounts.iter();
+        let pair = next_account(&mut iter)?;
+        let from_position = next_account(&mut iter)?;
+        let to_position = next_account(&mut iter)?;
+        let current_owner = next_account(&mut iter)?;
+        let new_owner = next_account(&mut iter)?;
+        let system_program = next_account(&mut iter)?;
+        let event_authority = next_account(&mut iter)?;
+        let program = next_account(&mut iter)?;
+
+        Some(TransferUserPositionInstructionAccounts {
+            pair,
+            from_position,
+            to_position,
+            current_owner,
+            new_owner,
+            system_program,
+            event_authority,
+            program,
+        })
+    }
+}

--- a/decoders/omnipair-decoder/src/instructions/user_position_transferred_event.rs
+++ b/decoders/omnipair-decoder/src/instructions/user_position_transferred_event.rs
@@ -1,0 +1,15 @@
+
+use super::super::types::*;
+
+use carbon_core::{borsh, CarbonDeserialize};
+
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash)]
+#[carbon(discriminator = "0xe445a52e51cb9a1d9fdec62ada5aac4b")]
+pub struct UserPositionTransferredEvent{
+    pub from_position: solana_pubkey::Pubkey,
+    pub to_position: solana_pubkey::Pubkey,
+    pub from_owner: solana_pubkey::Pubkey,
+    pub to_owner: solana_pubkey::Pubkey,
+    pub metadata: EventMetadata,
+}

--- a/decoders/omnipair-decoder/src/types/mod.rs
+++ b/decoders/omnipair-decoder/src/types/mod.rs
@@ -72,6 +72,8 @@ pub mod user_position_created_event;
 pub use user_position_created_event::*;
 pub mod user_position_liquidated_event;
 pub use user_position_liquidated_event::*;
+pub mod user_position_transferred_event;
+pub use user_position_transferred_event::*;
 pub mod user_position_updated_event;
 pub use user_position_updated_event::*;
 pub mod user_position_view_kind;

--- a/decoders/omnipair-decoder/src/types/user_position_transferred_event.rs
+++ b/decoders/omnipair-decoder/src/types/user_position_transferred_event.rs
@@ -1,0 +1,14 @@
+
+use super::*;
+
+use carbon_core::{CarbonDeserialize, borsh};
+
+
+#[derive(CarbonDeserialize, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Hash)]
+pub struct UserPositionTransferredEvent {
+    pub from_position: solana_pubkey::Pubkey,
+    pub to_position: solana_pubkey::Pubkey,
+    pub from_owner: solana_pubkey::Pubkey,
+    pub to_owner: solana_pubkey::Pubkey,
+    pub metadata: EventMetadata,
+}

--- a/programs/omnipair/Cargo.toml
+++ b/programs/omnipair/Cargo.toml
@@ -29,6 +29,7 @@ anchor-lang = { version = "0.31.1", features = ["init-if-needed", "event-cpi", "
 anchor-spl = { version = "0.31.1", features = ["metadata"] }
 spl-token = { version = "4.0.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "6.0.0", features = ["no-entrypoint"] }
+spl-memo = { version = "6.0.0", features = ["no-entrypoint"] }
 spl-math = { version = "0.3.0", features = ["no-entrypoint"] }
 solana-security-txt = "1.1.1"
 num-traits = "0.2.19"

--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -21,7 +21,7 @@ pub const LIQUIDATION_INCENTIVE_BPS: u16 = 50; // 0.5% liquidation incentive for
 #[constant]
 pub const LIQUIDATION_PENALTY_BPS: u16 = 300; // 3% total liquidation penalty (0.5% to liquidator, 2.5% to LPs)
 #[constant]
-pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 10_000; // 100% debt coverage required after liquidity withdrawal
+pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 11_500; // 115% debt coverage required after liquidity withdrawal
 #[constant]
 pub const PAIR_CREATION_FEE_LAMPORTS: u64 = 200_000_000; // 0.2 SOL
 // 3log2(100) = 19.93 secs (with 400ms slot time, this is ~50 slots)

--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -23,7 +23,7 @@ pub const LIQUIDATION_PENALTY_BPS: u16 = 300; // 3% total liquidation penalty (0
 #[constant]
 pub const LIQUIDITY_WITHDRAWAL_FEE_BPS: u16 = 100; // 1% fee on liquidity withdrawal (goes to remaining LPs)
 #[constant]
-pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 11_500; // 115% debt coverage required after liquidity withdrawal
+pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 10_000; // 100% debt coverage required after liquidity withdrawal
 #[constant]
 pub const PAIR_CREATION_FEE_LAMPORTS: u64 = 200_000_000; // 0.2 SOL
 // 3log2(100) = 19.93 secs (with 400ms slot time, this is ~50 slots)

--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -21,8 +21,6 @@ pub const LIQUIDATION_INCENTIVE_BPS: u16 = 50; // 0.5% liquidation incentive for
 #[constant]
 pub const LIQUIDATION_PENALTY_BPS: u16 = 300; // 3% total liquidation penalty (0.5% to liquidator, 2.5% to LPs)
 #[constant]
-pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 11_500; // 115% debt coverage required after liquidity withdrawal
-#[constant]
 pub const PAIR_CREATION_FEE_LAMPORTS: u64 = 200_000_000; // 0.2 SOL
 // 3log2(100) = 19.93 secs (with 400ms slot time, this is ~50 slots)
 #[constant]

--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -21,8 +21,6 @@ pub const LIQUIDATION_INCENTIVE_BPS: u16 = 50; // 0.5% liquidation incentive for
 #[constant]
 pub const LIQUIDATION_PENALTY_BPS: u16 = 300; // 3% total liquidation penalty (0.5% to liquidator, 2.5% to LPs)
 #[constant]
-pub const LIQUIDITY_WITHDRAWAL_FEE_BPS: u16 = 100; // 1% fee on liquidity withdrawal (goes to remaining LPs)
-#[constant]
 pub const POST_WITHDRAW_DEBT_COVERAGE_BPS: u16 = 10_000; // 100% debt coverage required after liquidity withdrawal
 #[constant]
 pub const PAIR_CREATION_FEE_LAMPORTS: u64 = 200_000_000; // 0.2 SOL

--- a/programs/omnipair/src/errors.rs
+++ b/programs/omnipair/src/errors.rs
@@ -89,6 +89,12 @@ pub enum ErrorCode {
     #[msg("User position not initialized")]
     UserPositionNotInitialized,
 
+    #[msg("Recipient position is not empty")]
+    RecipientPositionNotEmpty,
+
+    #[msg("Invalid position owner")]
+    InvalidPositionOwner,
+
     #[msg("Zero debt amount")]
     ZeroDebtAmount,
 

--- a/programs/omnipair/src/events.rs
+++ b/programs/omnipair/src/events.rs
@@ -150,6 +150,15 @@ pub struct UserPositionUpdatedEvent {
 }
 
 #[event]
+pub struct UserPositionTransferredEvent {
+    pub from_position: Pubkey,
+    pub to_position: Pubkey,
+    pub from_owner: Pubkey,
+    pub to_owner: Pubkey,
+    pub metadata: EventMetadata,
+}
+
+#[event]
 pub struct UserPositionLiquidatedEvent {
     pub position: Pubkey,
     pub liquidator: Pubkey,

--- a/programs/omnipair/src/instructions/futarchy/claim_protocol_fees.rs
+++ b/programs/omnipair/src/instructions/futarchy/claim_protocol_fees.rs
@@ -1,24 +1,24 @@
-use anchor_lang::prelude::*;
-use anchor_spl::{
-    token::{Token, TokenAccount, Mint},
-    token_interface::Token2022,
-    associated_token::AssociatedToken,
-};
 use crate::{
-    state::*,
     constants::*,
     errors::ErrorCode,
     events::{ClaimProtocolFeesEvent, EventMetadata},
-    utils::token::transfer_from_vault_to_vault,
     generate_gamm_pair_seeds,
+    state::*,
+    utils::token::{token_program_for_mint, transfer_from_vault_to_vault},
+};
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{create_idempotent, AssociatedToken},
+    token::Token,
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 
 /// Claims protocol fees from a pair and distributes them directly to revenue recipients.
-/// 
+///
 /// This instruction is permissionless - anyone can call it to trigger fee distribution.
 /// Fees are transferred directly from pair reserve vaults to recipient ATAs based on
 /// the distribution percentages stored in FutarchyAuthority.
-/// 
+///
 /// The recipient addresses in FutarchyAuthority are pubkeys not ATAs.
 /// ATAs are derived at runtime for each token being claimed.
 #[event_cpi]
@@ -57,7 +57,7 @@ pub struct ClaimProtocolFees<'info> {
         ],
         bump = pair.vault_bumps.reserve0
     )]
-    pub reserve0_vault: Box<Account<'info, TokenAccount>>,
+    pub reserve0_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
@@ -68,73 +68,49 @@ pub struct ClaimProtocolFees<'info> {
         ],
         bump = pair.vault_bumps.reserve1
     )]
-    pub reserve1_vault: Box<Account<'info, TokenAccount>>,
+    pub reserve1_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     // Token Mints
     #[account(address = pair.token0)]
-    pub token0_mint: Box<Account<'info, Mint>>,
-    
+    pub token0_mint: Box<InterfaceAccount<'info, Mint>>,
+
     #[account(address = pair.token1)]
-    pub token1_mint: Box<Account<'info, Mint>>,
+    pub token1_mint: Box<InterfaceAccount<'info, Mint>>,
 
     // Futarchy Treasury ATAs (boxed to reduce stack usage)
-    #[account(
-        init_if_needed,
-        payer = caller,
-        associated_token::mint = token0_mint,
-        associated_token::authority = futarchy_treasury,
-    )]
-    pub futarchy_treasury_token0: Box<Account<'info, TokenAccount>>,
+    #[account(mut)]
+    /// CHECK: Created/validated as the recipient ATA in the handler.
+    pub futarchy_treasury_token0: UncheckedAccount<'info>,
 
-    #[account(
-        init_if_needed,
-        payer = caller,
-        associated_token::mint = token1_mint,
-        associated_token::authority = futarchy_treasury,
-    )]
-    pub futarchy_treasury_token1: Box<Account<'info, TokenAccount>>,
+    #[account(mut)]
+    /// CHECK: Created/validated as the recipient ATA in the handler.
+    pub futarchy_treasury_token1: UncheckedAccount<'info>,
 
     /// CHECK: Validated against futarchy_authority.recipients.futarchy_treasury
     #[account(address = futarchy_authority.recipients.futarchy_treasury @ ErrorCode::InvalidRecipient)]
     pub futarchy_treasury: AccountInfo<'info>,
 
     // Buybacks Vault ATAs (boxed to reduce stack usage)
-    #[account(
-        init_if_needed,
-        payer = caller,
-        associated_token::mint = token0_mint,
-        associated_token::authority = buybacks_vault,
-    )]
-    pub buybacks_vault_token0: Box<Account<'info, TokenAccount>>,
+    #[account(mut)]
+    /// CHECK: Created/validated as the recipient ATA in the handler.
+    pub buybacks_vault_token0: UncheckedAccount<'info>,
 
-    #[account(
-        init_if_needed,
-        payer = caller,
-        associated_token::mint = token1_mint,
-        associated_token::authority = buybacks_vault,
-    )]
-    pub buybacks_vault_token1: Box<Account<'info, TokenAccount>>,
+    #[account(mut)]
+    /// CHECK: Created/validated as the recipient ATA in the handler.
+    pub buybacks_vault_token1: UncheckedAccount<'info>,
 
     /// CHECK: Validated against futarchy_authority.recipients.buybacks_vault
     #[account(address = futarchy_authority.recipients.buybacks_vault @ ErrorCode::InvalidRecipient)]
     pub buybacks_vault: AccountInfo<'info>,
 
     // Team Treasury ATAs (boxed to reduce stack usage)
-    #[account(
-        init_if_needed,
-        payer = caller,
-        associated_token::mint = token0_mint,
-        associated_token::authority = team_treasury,
-    )]
-    pub team_treasury_token0: Box<Account<'info, TokenAccount>>,
+    #[account(mut)]
+    /// CHECK: Created/validated as the recipient ATA in the handler.
+    pub team_treasury_token0: UncheckedAccount<'info>,
 
-    #[account(
-        init_if_needed,
-        payer = caller,
-        associated_token::mint = token1_mint,
-        associated_token::authority = team_treasury,
-    )]
-    pub team_treasury_token1: Box<Account<'info, TokenAccount>>,
+    #[account(mut)]
+    /// CHECK: Created/validated as the recipient ATA in the handler.
+    pub team_treasury_token1: UncheckedAccount<'info>,
 
     /// CHECK: Validated against futarchy_authority.recipients.team_treasury
     #[account(address = futarchy_authority.recipients.team_treasury @ ErrorCode::InvalidRecipient)]
@@ -159,13 +135,13 @@ impl<'info> ClaimProtocolFees<'info> {
     }
 
     pub fn handle_claim(ctx: Context<Self>) -> Result<()> {
-        let ClaimProtocolFees { 
-            pair, 
-            reserve0_vault, 
-            reserve1_vault, 
+        let ClaimProtocolFees {
+            pair,
+            reserve0_vault,
+            reserve1_vault,
             futarchy_authority,
             caller,
-            .. 
+            ..
         } = ctx.accounts;
 
         // Defensive check: ensure distribution percentages sum to 100%
@@ -218,17 +194,71 @@ impl<'info> ClaimProtocolFees<'info> {
         let signer_seeds = &[&pair_seeds[..]];
 
         // Determine token programs
-        let token0_program = if ctx.accounts.token0_mint.to_account_info().owner == ctx.accounts.token_program.key {
-            ctx.accounts.token_program.to_account_info()
-        } else {
-            ctx.accounts.token_2022_program.to_account_info()
-        };
+        let token0_program = token_program_for_mint(
+            &ctx.accounts.token0_mint.to_account_info(),
+            &ctx.accounts.token_program.to_account_info(),
+            &ctx.accounts.token_2022_program.to_account_info(),
+        )?;
+        let token1_program = token_program_for_mint(
+            &ctx.accounts.token1_mint.to_account_info(),
+            &ctx.accounts.token_program.to_account_info(),
+            &ctx.accounts.token_2022_program.to_account_info(),
+        )?;
 
-        let token1_program = if ctx.accounts.token1_mint.to_account_info().owner == ctx.accounts.token_program.key {
-            ctx.accounts.token_program.to_account_info()
-        } else {
-            ctx.accounts.token_2022_program.to_account_info()
-        };
+        create_recipient_ata(
+            ctx.accounts.associated_token_program.to_account_info(),
+            caller.to_account_info(),
+            ctx.accounts.futarchy_treasury_token0.to_account_info(),
+            ctx.accounts.futarchy_treasury.to_account_info(),
+            ctx.accounts.token0_mint.to_account_info(),
+            ctx.accounts.system_program.to_account_info(),
+            token0_program.clone(),
+        )?;
+        create_recipient_ata(
+            ctx.accounts.associated_token_program.to_account_info(),
+            caller.to_account_info(),
+            ctx.accounts.futarchy_treasury_token1.to_account_info(),
+            ctx.accounts.futarchy_treasury.to_account_info(),
+            ctx.accounts.token1_mint.to_account_info(),
+            ctx.accounts.system_program.to_account_info(),
+            token1_program.clone(),
+        )?;
+        create_recipient_ata(
+            ctx.accounts.associated_token_program.to_account_info(),
+            caller.to_account_info(),
+            ctx.accounts.buybacks_vault_token0.to_account_info(),
+            ctx.accounts.buybacks_vault.to_account_info(),
+            ctx.accounts.token0_mint.to_account_info(),
+            ctx.accounts.system_program.to_account_info(),
+            token0_program.clone(),
+        )?;
+        create_recipient_ata(
+            ctx.accounts.associated_token_program.to_account_info(),
+            caller.to_account_info(),
+            ctx.accounts.buybacks_vault_token1.to_account_info(),
+            ctx.accounts.buybacks_vault.to_account_info(),
+            ctx.accounts.token1_mint.to_account_info(),
+            ctx.accounts.system_program.to_account_info(),
+            token1_program.clone(),
+        )?;
+        create_recipient_ata(
+            ctx.accounts.associated_token_program.to_account_info(),
+            caller.to_account_info(),
+            ctx.accounts.team_treasury_token0.to_account_info(),
+            ctx.accounts.team_treasury.to_account_info(),
+            ctx.accounts.token0_mint.to_account_info(),
+            ctx.accounts.system_program.to_account_info(),
+            token0_program.clone(),
+        )?;
+        create_recipient_ata(
+            ctx.accounts.associated_token_program.to_account_info(),
+            caller.to_account_info(),
+            ctx.accounts.team_treasury_token1.to_account_info(),
+            ctx.accounts.team_treasury.to_account_info(),
+            ctx.accounts.token1_mint.to_account_info(),
+            ctx.accounts.system_program.to_account_info(),
+            token1_program.clone(),
+        )?;
 
         // Token0 transfers
         // Transfer to futarchy treasury
@@ -331,4 +361,26 @@ impl<'info> ClaimProtocolFees<'info> {
 
         Ok(())
     }
+}
+
+fn create_recipient_ata<'a>(
+    associated_token_program: AccountInfo<'a>,
+    payer: AccountInfo<'a>,
+    associated_token: AccountInfo<'a>,
+    authority: AccountInfo<'a>,
+    mint: AccountInfo<'a>,
+    system_program: AccountInfo<'a>,
+    token_program: AccountInfo<'a>,
+) -> Result<()> {
+    create_idempotent(CpiContext::new(
+        associated_token_program,
+        anchor_spl::associated_token::Create {
+            payer,
+            associated_token,
+            authority,
+            mint,
+            system_program,
+            token_program,
+        },
+    ))
 }

--- a/programs/omnipair/src/instructions/lending/add_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/add_collateral.rs
@@ -1,15 +1,23 @@
+use crate::{
+    constants::*,
+    errors::ErrorCode,
+    events::{
+        AdjustCollateralEvent, EventMetadata, UserPositionCreatedEvent, UserPositionUpdatedEvent,
+    },
+    instructions::lending::common::AdjustCollateralArgs,
+    state::{
+        futarchy_authority::FutarchyAuthority, pair::Pair, rate_model::RateModel,
+        user_position::UserPosition,
+    },
+    utils::{
+        account::get_size_with_discriminator,
+        token::{amount_with_transfer_fee, token_program_for_mint, transfer_from_user_to_vault},
+    },
+};
 use anchor_lang::prelude::*;
 use anchor_spl::{
-    token::{Token, TokenAccount, Mint},
-    token_interface::{Token2022},
-};
-use crate::{
-    errors::ErrorCode,
-    events::{AdjustCollateralEvent, EventMetadata, UserPositionCreatedEvent, UserPositionUpdatedEvent},
-    utils::{token::transfer_from_user_to_vault, account::get_size_with_discriminator},
-    instructions::lending::common::AdjustCollateralArgs,
-    state::{user_position::UserPosition, pair::Pair, rate_model::RateModel, futarchy_authority::FutarchyAuthority},
-    constants::*,
+    token::Token,
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 
 #[event_cpi]
@@ -63,19 +71,19 @@ pub struct AddCollateral<'info> {
         ],
         bump = pair.get_collateral_vault_bump(&collateral_token_mint.key())
     )]
-    pub collateral_vault: Box<Account<'info, TokenAccount>>,
+    pub collateral_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
         constraint = user_collateral_token_account.mint == pair.token0 || user_collateral_token_account.mint == pair.token1,
-        token::authority = user,
+        constraint = user_collateral_token_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_collateral_token_account: Box<Account<'info, TokenAccount>>,
+    pub user_collateral_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         constraint = collateral_token_mint.key() == pair.token0 || collateral_token_mint.key() == pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub collateral_token_mint: Box<Account<'info, Mint>>,
+    pub collateral_token_mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(mut)]
     pub user: Signer<'info>,
@@ -87,18 +95,20 @@ pub struct AddCollateral<'info> {
 impl<'info> AddCollateral<'info> {
     pub fn validate_add(&self, args: &AdjustCollateralArgs) -> Result<()> {
         let AdjustCollateralArgs { amount } = args;
-        
+
         require!(*amount > 0, ErrorCode::AmountZero);
-        
+
+        let transfer_amount =
+            amount_with_transfer_fee(&self.collateral_token_mint.to_account_info(), *amount)?;
         require_gte!(
             self.user_collateral_token_account.amount,
-            *amount,
+            transfer_amount,
             ErrorCode::InsufficientBalanceForCollateral
         );
-        
+
         Ok(())
     }
-    
+
     pub fn update(&mut self) -> Result<()> {
         let pair_key = self.pair.to_account_info().key();
         self.pair.update(
@@ -117,9 +127,9 @@ impl<'info> AddCollateral<'info> {
     }
 
     pub fn handle_add_collateral(ctx: Context<Self>, args: AdjustCollateralArgs) -> Result<()> {
-        let AddCollateral { 
-            pair, 
-            user, 
+        let AddCollateral {
+            pair,
+            user,
             collateral_vault,
             collateral_token_mint,
             token_program,
@@ -130,11 +140,7 @@ impl<'info> AddCollateral<'info> {
         } = ctx.accounts;
 
         if !user_position.is_initialized() {
-            user_position.initialize(
-                user.key(),
-                pair.key(),
-                ctx.bumps.user_position,
-            )?;
+            user_position.initialize(user.key(), pair.key(), ctx.bumps.user_position)?;
 
             emit_cpi!(UserPositionCreatedEvent {
                 metadata: EventMetadata::new(user.key(), pair.key()),
@@ -150,22 +156,25 @@ impl<'info> AddCollateral<'info> {
             user_collateral_token_account.to_account_info(),
             collateral_vault.to_account_info(),
             collateral_token_mint.to_account_info(),
-            match collateral_token_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
-            args.amount,
+            token_program_for_mint(
+                &collateral_token_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
+            amount_with_transfer_fee(&collateral_token_mint.to_account_info(), args.amount)?,
             collateral_token_mint.decimals,
         )?;
 
         match is_collateral_token0 {
             true => {
                 pair.total_collateral0 = pair.total_collateral0.checked_add(args.amount).unwrap();
-                user_position.collateral0 = user_position.collateral0.checked_add(args.amount).unwrap();
-            },
+                user_position.collateral0 =
+                    user_position.collateral0.checked_add(args.amount).unwrap();
+            }
             false => {
                 pair.total_collateral1 = pair.total_collateral1.checked_add(args.amount).unwrap();
-                user_position.collateral1 = user_position.collateral1.checked_add(args.amount).unwrap();
+                user_position.collateral1 =
+                    user_position.collateral1.checked_add(args.amount).unwrap();
             }
         }
 
@@ -175,7 +184,7 @@ impl<'info> AddCollateral<'info> {
         } else {
             (0, args.amount as i64)
         };
-        
+
         emit_cpi!(AdjustCollateralEvent {
             metadata: EventMetadata::new(user.key(), pair.key()),
             amount0,

--- a/programs/omnipair/src/instructions/lending/borrow.rs
+++ b/programs/omnipair/src/instructions/lending/borrow.rs
@@ -177,10 +177,10 @@ impl<'info> Borrow<'info> {
             false => user_position.calculate_debt1(pair.total_debt1, pair.total_debt1_shares)?,
         };
 
-        // If EMA lags behind a falling spot price, there will be a window where the collateral value may be artificially inflated.
-        // To prevent bad debt, we compute a pessimistic collateral factor:
-        // CF_pessimistic = min(CF_base, P_spot / P_EMA * CF_base)
-        // This ensures the solvency invariant: P_spot >= P_EMA * CF
+        // Borrowing is a user-initiated risk increase, so it uses the directional
+        // EMA path to prevent front-running stale symmetric EMA after spot falls.
+        // Liquidation intentionally does not use this snap-down price, because that
+        // would let an attacker dump spot and immediately liquidate borrowers.
         let collateral_token = pair.get_collateral_token(&debt_token);
         let collateral_amount = match collateral_token == pair.token0 {
             true => user_position.collateral0,

--- a/programs/omnipair/src/instructions/lending/borrow.rs
+++ b/programs/omnipair/src/instructions/lending/borrow.rs
@@ -177,10 +177,10 @@ impl<'info> Borrow<'info> {
             false => user_position.calculate_debt1(pair.total_debt1, pair.total_debt1_shares)?,
         };
 
-        // Borrowing is a user-initiated risk increase, so it uses the directional
-        // EMA path to prevent front-running stale symmetric EMA after spot falls.
-        // Liquidation intentionally does not use this snap-down price, because that
-        // would let an attacker dump spot and immediately liquidate borrowers.
+        // If EMA lags behind a falling spot price, there will be a window where the collateral value may be artificially inflated.
+        // To prevent bad debt, we compute a pessimistic collateral factor:
+        // CF_pessimistic = min(CF_base, P_spot / P_EMA * CF_base)
+        // This ensures the solvency invariant: P_spot >= P_EMA * CF
         let collateral_token = pair.get_collateral_token(&debt_token);
         let collateral_amount = match collateral_token == pair.token0 {
             true => user_position.collateral0,

--- a/programs/omnipair/src/instructions/lending/borrow.rs
+++ b/programs/omnipair/src/instructions/lending/borrow.rs
@@ -1,8 +1,8 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::sysvar;
 use anchor_spl::{
-    token::{Mint, Token, TokenAccount},
-    token_interface::Token2022,
+    token::Token,
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 
 use crate::{
@@ -17,7 +17,7 @@ use crate::{
     },
     utils::{
         liquidity_delta_circuit_breaker::require_no_same_tx_liquidity_delta,
-        token::transfer_from_vault_to_user,
+        token::{token_program_for_mint, transfer_from_vault_to_user},
     },
 };
 
@@ -70,19 +70,19 @@ pub struct Borrow<'info> {
         ],
         bump = pair.get_reserve_vault_bump(&reserve_token_mint.key())
     )]
-    pub reserve_vault: Box<Account<'info, TokenAccount>>,
+    pub reserve_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
         constraint = user_reserve_token_account.mint == reserve_token_mint.key() @ ErrorCode::InvalidMint,
-        token::authority = user,
+        constraint = user_reserve_token_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_reserve_token_account: Box<Account<'info, TokenAccount>>,
+    pub user_reserve_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         constraint = reserve_token_mint.key() == pair.token0 || reserve_token_mint.key() == pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub reserve_token_mint: Box<Account<'info, Mint>>,
+    pub reserve_token_mint: Box<InterfaceAccount<'info, Mint>>,
 
     pub user: Signer<'info>,
     pub token_program: Program<'info, Token>,
@@ -219,10 +219,11 @@ impl<'info> Borrow<'info> {
             debt_token_vault.to_account_info(),
             user_reserve_token_account.to_account_info(),
             reserve_token_mint.to_account_info(),
-            match reserve_token_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
+            token_program_for_mint(
+                &reserve_token_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
             borrow_amount,
             reserve_token_mint.decimals,
             &[&generate_gamm_pair_seeds!(pair)[..]],

--- a/programs/omnipair/src/instructions/lending/common.rs
+++ b/programs/omnipair/src/instructions/lending/common.rs
@@ -1,18 +1,11 @@
-use anchor_lang::{
-    prelude::*,
-    solana_program::sysvar,
-};
-use anchor_spl::{
-    token::{Token, TokenAccount, Mint},
-    token_interface::{Token2022},
-};
 use crate::{
-    state::pair::Pair,
-    state::rate_model::RateModel,
-    state::user_position::UserPosition,
-    state::futarchy_authority::FutarchyAuthority,
-    constants::*,
-    errors::ErrorCode,
+    constants::*, errors::ErrorCode, state::futarchy_authority::FutarchyAuthority,
+    state::pair::Pair, state::rate_model::RateModel, state::user_position::UserPosition,
+};
+use anchor_lang::{prelude::*, solana_program::sysvar};
+use anchor_spl::{
+    token::Token,
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -69,19 +62,19 @@ pub struct CommonAdjustCollateral<'info> {
         ],
         bump = pair.get_collateral_vault_bump(&collateral_token_mint.key())
     )]
-    pub collateral_vault: Box<Account<'info, TokenAccount>>,
+    pub collateral_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
         constraint = user_collateral_token_account.mint == pair.token0 || user_collateral_token_account.mint == pair.token1,
-        token::authority = user,
+        constraint = user_collateral_token_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_collateral_token_account: Box<Account<'info, TokenAccount>>,
+    pub user_collateral_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         constraint = collateral_token_mint.key() == pair.token0 || collateral_token_mint.key() == pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub collateral_token_mint: Box<Account<'info, Mint>>,
+    pub collateral_token_mint: Box<InterfaceAccount<'info, Mint>>,
 
     pub user: Signer<'info>,
     pub token_program: Program<'info, Token>,
@@ -161,19 +154,19 @@ pub struct CommonAdjustDebt<'info> {
         ],
         bump = pair.get_reserve_vault_bump(&reserve_token_mint.key())
     )]
-    pub reserve_vault: Box<Account<'info, TokenAccount>>,
+    pub reserve_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
         constraint = user_reserve_token_account.mint == pair.token0 || user_reserve_token_account.mint == pair.token1,
-        token::authority = user,
+        constraint = user_reserve_token_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_reserve_token_account: Box<Account<'info, TokenAccount>>,
+    pub user_reserve_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         constraint = reserve_token_mint.key() == pair.token0 || reserve_token_mint.key() == pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub reserve_token_mint: Box<Account<'info, Mint>>,
+    pub reserve_token_mint: Box<InterfaceAccount<'info, Mint>>,
 
     pub user: Signer<'info>,
     pub token_program: Program<'info, Token>,

--- a/programs/omnipair/src/instructions/lending/flashloan.rs
+++ b/programs/omnipair/src/instructions/lending/flashloan.rs
@@ -1,20 +1,23 @@
-use anchor_lang::prelude::*;
-use anchor_lang::solana_program::{
-    instruction::{Instruction, AccountMeta},
-    program::invoke,
-    hash::hash,
-};
-use anchor_spl::{
-    token::{Token, TokenAccount, Mint},
-    token_interface::{Token2022},
-};
 use crate::{
-    state::*,
     constants::*,
     errors::ErrorCode,
     events::*,
-    utils::{token::{transfer_from_vault_to_user, sync_native_if_wsol}, math::ceil_div},
     generate_gamm_pair_seeds,
+    state::*,
+    utils::{
+        math::ceil_div,
+        token::{sync_native_if_wsol, token_program_for_mint, transfer_from_vault_to_user},
+    },
+};
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{
+    hash::hash,
+    instruction::{AccountMeta, Instruction},
+    program::invoke,
+};
+use anchor_spl::{
+    token::Token,
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -55,7 +58,7 @@ pub struct Flashloan<'info> {
         bump = futarchy_authority.bump
     )]
     pub futarchy_authority: Account<'info, FutarchyAuthority>,
-    
+
     #[account(
         mut,
         seeds = [
@@ -65,8 +68,8 @@ pub struct Flashloan<'info> {
         ],
         bump = pair.vault_bumps.reserve0
     )]
-    pub reserve0_vault: Account<'info, TokenAccount>,
-    
+    pub reserve0_vault: InterfaceAccount<'info, TokenAccount>,
+
     #[account(
         mut,
         seeds = [
@@ -76,49 +79,46 @@ pub struct Flashloan<'info> {
         ],
         bump = pair.vault_bumps.reserve1
     )]
-    pub reserve1_vault: Account<'info, TokenAccount>,
+    pub reserve1_vault: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         address = pair.token0 @ ErrorCode::InvalidMint
     )]
-    pub token0_mint: Box<Account<'info, Mint>>,
-    
+    pub token0_mint: Box<InterfaceAccount<'info, Mint>>,
+
     #[account(
         address = pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub token1_mint: Box<Account<'info, Mint>>,
+    pub token1_mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         mut,
         constraint = receiver_token0_account.mint == pair.token0,
     )]
-    pub receiver_token0_account: Account<'info, TokenAccount>,
-    
+    pub receiver_token0_account: InterfaceAccount<'info, TokenAccount>,
+
     #[account(
         mut,
         constraint = receiver_token1_account.mint == pair.token1,
     )]
-    pub receiver_token1_account: Account<'info, TokenAccount>,
+    pub receiver_token1_account: InterfaceAccount<'info, TokenAccount>,
 
     /// CHECK: The receiver program that implements the flash loan callback
     /// This program will be invoked via CPI
     pub receiver_program: UncheckedAccount<'info>,
-    
+
     pub user: Signer<'info>,
     pub token_program: Program<'info, Token>,
     pub token_2022_program: Program<'info, Token2022>,
-    
+
     /// CHECK: System program for CPI
     pub system_program: Program<'info, System>,
 }
 
 impl<'info> Flashloan<'info> {
     pub fn validate(&self, args: &FlashloanArgs) -> Result<()> {
-        require!(
-            args.amount0 > 0 || args.amount1 > 0,
-            ErrorCode::AmountZero
-        );
-        
+        require!(args.amount0 > 0 || args.amount1 > 0, ErrorCode::AmountZero);
+
         // Ensure loan amounts doesn't exceed available cash reserves
         if args.amount0 > 0 {
             require_gte!(
@@ -127,7 +127,7 @@ impl<'info> Flashloan<'info> {
                 ErrorCode::BorrowExceedsReserve
             );
         }
-        
+
         if args.amount1 > 0 {
             require_gte!(
                 self.pair.cash_reserve1,
@@ -135,7 +135,7 @@ impl<'info> Flashloan<'info> {
                 ErrorCode::BorrowExceedsReserve
             );
         }
-        
+
         Ok(())
     }
 
@@ -156,7 +156,10 @@ impl<'info> Flashloan<'info> {
         Ok(())
     }
 
-    pub fn handle_flashloan(ctx: Context<'_, '_, '_, 'info, Self>, args: FlashloanArgs) -> Result<()> {
+    pub fn handle_flashloan(
+        ctx: Context<'_, '_, '_, 'info, Self>,
+        args: FlashloanArgs,
+    ) -> Result<()> {
         let Flashloan {
             pair,
             reserve0_vault,
@@ -172,24 +175,40 @@ impl<'info> Flashloan<'info> {
             ..
         } = ctx.accounts;
 
-        let FlashloanArgs { amount0, amount1, data } = args;
+        let FlashloanArgs {
+            amount0,
+            amount1,
+            data,
+        } = args;
 
         // Calculate fees (5 bps = 0.05%)
-        let fee0 = ceil_div((amount0 as u128)
-            .checked_mul(FLASHLOAN_FEE_BPS as u128)
-            .ok_or(ErrorCode::FeeMathOverflow)?,
+        let fee0 = ceil_div(
+            (amount0 as u128)
+                .checked_mul(FLASHLOAN_FEE_BPS as u128)
+                .ok_or(ErrorCode::FeeMathOverflow)?,
             BPS_DENOMINATOR as u128,
-        ).ok_or(ErrorCode::FeeMathOverflow)? as u64;
-        
-        let fee1 = ceil_div((amount1 as u128)
-            .checked_mul(FLASHLOAN_FEE_BPS as u128)
-            .ok_or(ErrorCode::FeeMathOverflow)?,
+        )
+        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
+
+        let fee1 = ceil_div(
+            (amount1 as u128)
+                .checked_mul(FLASHLOAN_FEE_BPS as u128)
+                .ok_or(ErrorCode::FeeMathOverflow)?,
             BPS_DENOMINATOR as u128,
-        ).ok_or(ErrorCode::FeeMathOverflow)? as u64;
+        )
+        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
 
         // Sync native SOL for WSOL vaults before recording balances
-        sync_native_if_wsol(&pair.token0, &reserve0_vault.to_account_info(), &token_program.to_account_info())?;
-        sync_native_if_wsol(&pair.token1, &reserve1_vault.to_account_info(), &token_program.to_account_info())?;
+        sync_native_if_wsol(
+            &pair.token0,
+            &reserve0_vault.to_account_info(),
+            &token_program.to_account_info(),
+        )?;
+        sync_native_if_wsol(
+            &pair.token1,
+            &reserve1_vault.to_account_info(),
+            &token_program.to_account_info(),
+        )?;
 
         // Record balances before the flash loan
         reserve0_vault.reload()?;
@@ -204,10 +223,11 @@ impl<'info> Flashloan<'info> {
                 reserve0_vault.to_account_info(),
                 receiver_token0_account.to_account_info(),
                 token0_mint.to_account_info(),
-                match token0_mint.to_account_info().owner == token_program.key {
-                    true => token_program.to_account_info(),
-                    false => token_2022_program.to_account_info(),
-                },
+                token_program_for_mint(
+                    &token0_mint.to_account_info(),
+                    &token_program.to_account_info(),
+                    &token_2022_program.to_account_info(),
+                )?,
                 amount0,
                 token0_mint.decimals,
                 &[&generate_gamm_pair_seeds!(pair)[..]],
@@ -220,16 +240,17 @@ impl<'info> Flashloan<'info> {
                 reserve1_vault.to_account_info(),
                 receiver_token1_account.to_account_info(),
                 token1_mint.to_account_info(),
-                match token1_mint.to_account_info().owner == token_program.key {
-                    true => token_program.to_account_info(),
-                    false => token_2022_program.to_account_info(),
-                },
+                token_program_for_mint(
+                    &token1_mint.to_account_info(),
+                    &token_program.to_account_info(),
+                    &token_2022_program.to_account_info(),
+                )?,
                 amount1,
                 token1_mint.decimals,
                 &[&generate_gamm_pair_seeds!(pair)[..]],
             )?;
         }
-        
+
         // Prepare callback data
         let callback_data = FlashLoanCallbackData {
             initiator: user.key(),
@@ -241,19 +262,19 @@ impl<'info> Flashloan<'info> {
         // Build the instruction data with Anchor discriminator
         // Anchor computes discriminators as: first 8 bytes of SHA256("global:instruction_name")
         let discriminator = &hash(b"global:flash_loan_callback").to_bytes()[..8];
-        
+
         let mut callback_instruction_data = Vec::new();
         callback_instruction_data.extend_from_slice(discriminator);
         callback_data.serialize(&mut callback_instruction_data)?;
 
-        // Build account metas for the CPI instruction  
+        // Build account metas for the CPI instruction
         // Order must match the receiver's FlashLoanCallback account struct
         let mut callback_account_metas = vec![
-            AccountMeta::new_readonly(user.key(), true),           // initiator
+            AccountMeta::new_readonly(user.key(), true), // initiator
             AccountMeta::new(receiver_token0_account.key(), false), // receiver_token0_account
             AccountMeta::new(receiver_token1_account.key(), false), // receiver_token1_account
-            AccountMeta::new_readonly(token0_mint.key(), false),    // token0_mint
-            AccountMeta::new_readonly(token1_mint.key(), false),    // token1_mint
+            AccountMeta::new_readonly(token0_mint.key(), false), // token0_mint
+            AccountMeta::new_readonly(token1_mint.key(), false), // token1_mint
         ];
 
         // Add remaining accounts (vaults + any additional accounts)
@@ -265,9 +286,10 @@ impl<'info> Flashloan<'info> {
                 is_writable: acc.is_writable,
             });
         }
-        
-        // Add token_program as the last account
+
+        // Add token programs after receiver-specific accounts.
         callback_account_metas.push(AccountMeta::new_readonly(token_program.key(), false));
+        callback_account_metas.push(AccountMeta::new_readonly(token_2022_program.key(), false));
 
         // Build the CPI instruction to the receiver program
         let callback_instruction = Instruction {
@@ -276,25 +298,28 @@ impl<'info> Flashloan<'info> {
             data: callback_instruction_data,
         };
 
-        // Execute the CPI callback
-        // Create a slice of base accounts, then we'll include remaining accounts
+        // Execute the CPI callback with account infos ordered to match callback_account_metas.
         let base_accounts = &[
             user.to_account_info(),
             receiver_token0_account.to_account_info(),
             receiver_token1_account.to_account_info(),
             token0_mint.to_account_info(),
             token1_mint.to_account_info(),
-            token_program.to_account_info(),
         ];
-        
-        // For the CPI, we need to pass all account infos
-        // Combine base accounts with remaining accounts into a single slice
-        let all_accounts = [base_accounts, ctx.remaining_accounts].concat();
+        let token_program_accounts = &[
+            token_program.to_account_info(),
+            token_2022_program.to_account_info(),
+        ];
 
-        invoke(
-            &callback_instruction,
-            &all_accounts,
-        )?;
+        // For the CPI, we need to pass all account infos.
+        let all_accounts = [
+            base_accounts,
+            ctx.remaining_accounts,
+            token_program_accounts,
+        ]
+        .concat();
+
+        invoke(&callback_instruction, &all_accounts)?;
 
         // Reload vault accounts to get updated balances after callback execution
         reserve0_vault.reload()?;

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -249,19 +249,11 @@ impl<'info> Liquidate<'info> {
 
         require!(collateral_ema_nad > 0, ErrorCode::InsufficientLiquidity);
 
-        // Reference-price collateral value in debt-token units.
-        //
-        // Liquidation deliberately uses the symmetric EMA, not the directional EMA:
-        // snapping liquidation down to the latest lower spot would let an attacker
-        // dump the pool price and immediately liquidate otherwise healthy borrowers.
-        //
-        // Borrow, collateral removal, and liquidity removal use the directional EMA
-        // as an anti-front-running control for user-initiated risk increases. That
-        // check prevents borrowing/removing against a stale high EMA when spot has
-        // already fallen; it is not meant to be a liquidation trigger.
-        //
-        // This also avoids AMM depth/price-impact valuation so LP withdrawals do
-        // not move liquidation eligibility through reserve depth alone.
+        // Reference-price collateral value in debt-token units. Liquidation uses
+        // symmetric EMA, not directional EMA, to avoid dump-spot-and-liquidate attacks.
+        // Directional EMA is reserved for user-initiated risk increases (borrow/remove).
+        // This deliberately avoids AMM depth/price-impact valuation so LP withdrawals
+        // do not move liquidation eligibility through reserve depth alone.
         let collateral_value =
             collateral_value_at_reference_price(user_collateral, collateral_ema_nad)?;
 

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -306,7 +306,6 @@ impl<'info> Liquidate<'info> {
                 min(user_debt, debt as u64) // clamped to user's debt
             }
         };
-        require!(debt_to_reduce > 0, ErrorCode::ZeroDebtAmount);
 
         let max_repay_from_collateral = max_debt_repayable_by_collateral(
             user_collateral,
@@ -317,12 +316,19 @@ impl<'info> Liquidate<'info> {
             true => min(debt_to_reduce, max_repay_from_collateral),
             false => debt_to_reduce,
         };
-        require!(repay_amount > 0, ErrorCode::InsufficientDebt);
-        require_gte!(
-            liquidator_debt_token_account.amount,
+        validate_liquidation_progress(
+            is_insolvent,
+            shares_to_reduce,
+            debt_to_reduce,
             repay_amount,
-            ErrorCode::InsufficientBalance
-        );
+        )?;
+        if repay_amount > 0 {
+            require_gte!(
+                liquidator_debt_token_account.amount,
+                repay_amount,
+                ErrorCode::InsufficientBalance
+            );
+        }
 
         // Base collateral covers the repaid debt at the EMA reference price.
         let collateral_base =
@@ -384,15 +390,17 @@ impl<'info> Liquidate<'info> {
                 false => token_2022_program.to_account_info(),
             };
 
-        transfer_from_user_to_vault(
-            payer.to_account_info(),
-            liquidator_debt_token_account.to_account_info(),
-            debt_reserve_vault.to_account_info(),
-            debt_token_mint.to_account_info(),
-            debt_token_program,
-            repay_amount,
-            debt_token_mint.decimals,
-        )?;
+        if repay_amount > 0 {
+            transfer_from_user_to_vault(
+                payer.to_account_info(),
+                liquidator_debt_token_account.to_account_info(),
+                debt_reserve_vault.to_account_info(),
+                debt_token_mint.to_account_info(),
+                debt_token_program,
+                repay_amount,
+                debt_token_mint.decimals,
+            )?;
+        }
 
         // Pass exact shares to avoid edge cases where floor division leaves residual shares.
         user_position.decrease_debt(
@@ -584,6 +592,26 @@ fn max_debt_repayable_by_collateral(
     u64::try_from(repay_amount).map_err(|_| ErrorCode::DebtMathOverflow.into())
 }
 
+fn validate_liquidation_progress(
+    is_insolvent: bool,
+    shares_to_reduce: u128,
+    debt_to_reduce: u64,
+    repay_amount: u64,
+) -> Result<()> {
+    require!(shares_to_reduce > 0, ErrorCode::ZeroDebtAmount);
+
+    if is_insolvent {
+        // Insolvent cleanup must still be able to clear bad debt when the
+        // remaining collateral has zero repayable value after integer pricing.
+        return Ok(());
+    }
+
+    require!(debt_to_reduce > 0, ErrorCode::ZeroDebtAmount);
+    require!(repay_amount > 0, ErrorCode::InsufficientDebt);
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -630,5 +658,29 @@ mod tests {
             max_debt_repayable_by_collateral(103, NAD, LIQUIDATION_PENALTY_BPS).unwrap(),
             100
         );
+    }
+
+    #[test]
+    fn zero_value_insolvent_collateral_can_be_cleaned_up() {
+        assert_eq!(collateral_value_at_reference_price(1, 1).unwrap(), 0);
+        assert_eq!(
+            max_debt_repayable_by_collateral(1, 1, LIQUIDATION_PENALTY_BPS).unwrap(),
+            0
+        );
+        assert!(validate_liquidation_progress(true, 1, 1, 0).is_ok());
+    }
+
+    #[test]
+    fn insolvent_dust_shares_can_be_cleaned_up_without_nominal_debt() {
+        assert!(validate_liquidation_progress(true, 1, 0, 0).is_ok());
+    }
+
+    #[test]
+    fn solvent_zero_amount_liquidation_is_rejected() {
+        let err = validate_liquidation_progress(false, 1, 0, 0).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::ZeroDebtAmount));
+
+        let err = validate_liquidation_progress(false, 1, 1, 0).unwrap_err();
+        assert_eq!(err, error!(ErrorCode::InsufficientDebt));
     }
 }

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -10,7 +10,7 @@ use crate::{
     state::futarchy_authority::FutarchyAuthority,
     constants::*,
     errors::ErrorCode,
-    events::{AdjustDebtEvent, EventMetadata, UserPositionLiquidatedEvent, UserPositionUpdatedEvent},
+    events::{AdjustDebtEvent, EventMetadata, SwapEvent, UserPositionLiquidatedEvent, UserPositionUpdatedEvent},
     state::user_position::{UserPosition, DebtDecreaseReason},
     utils::{
         token::{transfer_from_vault_to_user, transfer_from_vault_to_vault}, 
@@ -357,6 +357,18 @@ impl<'info> Liquidate<'info> {
                 pair.cash_reserve1 = pair.cash_reserve1.saturating_add(collateral_to_reserves);
             }
         }
+
+        emit_cpi!(SwapEvent {
+            metadata: EventMetadata::new(payer.key(), pair.key()),
+            reserve0: pair.reserve0,
+            reserve1: pair.reserve1,
+            is_token0_in: is_collateral_token0,
+            amount_in: collateral_to_reserves,
+            amount_out: debt_to_writeoff,
+            amount_in_after_fee: collateral_to_reserves,
+            lp_fee: 0,
+            protocol_fee: 0,
+        });
 
         // Emit debt adjustment event (debt written off)
         let (amount0, amount1) = if is_collateral_token0 {

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -13,14 +13,15 @@ use crate::{
     utils::{
         math::ceil_div,
         token::{
+            amount_after_transfer_fee, amount_with_transfer_fee, token_program_for_mint,
             transfer_from_user_to_vault, transfer_from_vault_to_user, transfer_from_vault_to_vault,
         },
     },
 };
 use anchor_lang::prelude::*;
 use anchor_spl::{
-    token::{Mint, Token, TokenAccount},
-    token_interface::Token2022,
+    token::Token,
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 use std::cmp::min;
 
@@ -71,23 +72,23 @@ pub struct Liquidate<'info> {
         ],
         bump = pair.get_collateral_vault_bump(&collateral_token_mint.key())
     )]
-    pub collateral_vault: Box<Account<'info, TokenAccount>>,
+    pub collateral_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
         constraint = caller_token_account.mint == collateral_vault.mint,
     )]
-    pub caller_token_account: Box<Account<'info, TokenAccount>>,
+    pub caller_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         constraint = collateral_token_mint.key() == pair.token0 || collateral_token_mint.key() == pair.token1 @ ErrorCode::InvalidVault
     )]
-    pub collateral_token_mint: Box<Account<'info, Mint>>,
+    pub collateral_token_mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         constraint = debt_token_mint.key() == pair.get_debt_token(&collateral_token_mint.key()) @ ErrorCode::InvalidMint
     )]
-    pub debt_token_mint: Box<Account<'info, Mint>>,
+    pub debt_token_mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         mut,
@@ -98,14 +99,14 @@ pub struct Liquidate<'info> {
         ],
         bump = pair.get_reserve_vault_bump(&debt_token_mint.key())
     )]
-    pub debt_reserve_vault: Box<Account<'info, TokenAccount>>,
+    pub debt_reserve_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
         constraint = liquidator_debt_token_account.mint == debt_token_mint.key() @ ErrorCode::InvalidTokenAccount,
         constraint = liquidator_debt_token_account.owner == payer.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub liquidator_debt_token_account: Box<Account<'info, TokenAccount>>,
+    pub liquidator_debt_token_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
@@ -116,7 +117,7 @@ pub struct Liquidate<'info> {
         ],
         bump = pair.get_reserve_vault_bump(&collateral_token_mint.key())
     )]
-    pub collateral_reserve_vault: Box<Account<'info, TokenAccount>>,
+    pub collateral_reserve_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// CHECK: This is the owner of the position being liquidated.
     #[account(address = user_position.owner)]
@@ -329,9 +330,11 @@ impl<'info> Liquidate<'info> {
             require!(repay_amount > 0, ErrorCode::InsufficientDebt);
         }
         if repay_amount > 0 {
+            let repay_transfer_amount =
+                amount_with_transfer_fee(&debt_token_mint.to_account_info(), repay_amount)?;
             require_gte!(
                 liquidator_debt_token_account.amount,
-                repay_amount,
+                repay_transfer_amount,
                 ErrorCode::InsufficientBalance
             );
         }
@@ -383,18 +386,22 @@ impl<'info> Liquidate<'info> {
         let collateral_to_reserves = collateral_final
             .checked_sub(collateral_to_liquidator)
             .ok_or(ErrorCode::DebtMathOverflow)?;
+        let collateral_to_reserves_after_fee = amount_after_transfer_fee(
+            &collateral_token_mint.to_account_info(),
+            collateral_to_reserves,
+        )?;
         let liquidation_bonus = collateral_to_liquidator.saturating_sub(collateral_base);
 
-        let debt_token_program = match debt_token_mint.to_account_info().owner == token_program.key
-        {
-            true => token_program.to_account_info(),
-            false => token_2022_program.to_account_info(),
-        };
-        let collateral_token_program =
-            match collateral_token_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            };
+        let debt_token_program = token_program_for_mint(
+            &debt_token_mint.to_account_info(),
+            &token_program.to_account_info(),
+            &token_2022_program.to_account_info(),
+        )?;
+        let collateral_token_program = token_program_for_mint(
+            &collateral_token_mint.to_account_info(),
+            &token_program.to_account_info(),
+            &token_2022_program.to_account_info(),
+        )?;
 
         if repay_amount > 0 {
             transfer_from_user_to_vault(
@@ -403,7 +410,7 @@ impl<'info> Liquidate<'info> {
                 debt_reserve_vault.to_account_info(),
                 debt_token_mint.to_account_info(),
                 debt_token_program,
-                repay_amount,
+                amount_with_transfer_fee(&debt_token_mint.to_account_info(), repay_amount)?,
                 debt_token_mint.decimals,
             )?;
         }
@@ -459,8 +466,13 @@ impl<'info> Liquidate<'info> {
                     .checked_sub(collateral_final)
                     .unwrap();
                 // Add remaining collateral (after incentive) to reserves
-                pair.reserve0 = pair.reserve0.checked_add(collateral_to_reserves).unwrap();
-                pair.cash_reserve0 = pair.cash_reserve0.saturating_add(collateral_to_reserves);
+                pair.reserve0 = pair
+                    .reserve0
+                    .checked_add(collateral_to_reserves_after_fee)
+                    .unwrap();
+                pair.cash_reserve0 = pair
+                    .cash_reserve0
+                    .saturating_add(collateral_to_reserves_after_fee);
             }
             false => {
                 user_position.collateral1 = user_position
@@ -472,8 +484,13 @@ impl<'info> Liquidate<'info> {
                     .checked_sub(collateral_final)
                     .unwrap();
                 // Add remaining collateral (after incentive) to reserves
-                pair.reserve1 = pair.reserve1.checked_add(collateral_to_reserves).unwrap();
-                pair.cash_reserve1 = pair.cash_reserve1.saturating_add(collateral_to_reserves);
+                pair.reserve1 = pair
+                    .reserve1
+                    .checked_add(collateral_to_reserves_after_fee)
+                    .unwrap();
+                pair.cash_reserve1 = pair
+                    .cash_reserve1
+                    .saturating_add(collateral_to_reserves_after_fee);
             }
         }
 
@@ -616,5 +633,4 @@ mod tests {
             52
         );
     }
-
 }

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -254,8 +254,10 @@ impl<'info> Liquidate<'info> {
         // Directional EMA is reserved for user-initiated risk increases (borrow/remove).
         // This deliberately avoids AMM depth/price-impact valuation so LP withdrawals
         // do not move liquidation eligibility through reserve depth alone.
-        let collateral_value =
-            collateral_value_at_reference_price(user_collateral, collateral_ema_nad)?;
+        let collateral_value = (user_collateral as u128)
+            .checked_mul(collateral_ema_nad as u128)
+            .and_then(|value| value.checked_div(NAD as u128))
+            .ok_or(ErrorCode::DebtMathOverflow)?;
 
         // Borrow limit = collateral_value * liquidation_cf
         let borrow_limit = collateral_value
@@ -309,21 +311,23 @@ impl<'info> Liquidate<'info> {
             }
         };
 
-        let max_repay_from_collateral = max_debt_repayable_by_collateral(
-            user_collateral,
-            collateral_ema_nad,
-            LIQUIDATION_PENALTY_BPS,
-        )?;
+        let max_repay_from_collateral = collateral_value
+            .checked_mul(BPS_DENOMINATOR as u128)
+            .and_then(|value| {
+                value.checked_div((BPS_DENOMINATOR + LIQUIDATION_PENALTY_BPS) as u128)
+            })
+            .ok_or(ErrorCode::DebtMathOverflow)?;
+        let max_repay_from_collateral =
+            u64::try_from(max_repay_from_collateral).map_err(|_| ErrorCode::DebtMathOverflow)?;
         let repay_amount = match is_insolvent {
             true => min(debt_to_reduce, max_repay_from_collateral),
             false => debt_to_reduce,
         };
-        validate_liquidation_progress(
-            is_insolvent,
-            shares_to_reduce,
-            debt_to_reduce,
-            repay_amount,
-        )?;
+        require!(shares_to_reduce > 0, ErrorCode::ZeroDebtAmount);
+        if !is_insolvent {
+            require!(debt_to_reduce > 0, ErrorCode::ZeroDebtAmount);
+            require!(repay_amount > 0, ErrorCode::InsufficientDebt);
+        }
         if repay_amount > 0 {
             require_gte!(
                 liquidator_debt_token_account.amount,
@@ -550,14 +554,6 @@ impl<'info> Liquidate<'info> {
     }
 }
 
-fn collateral_value_at_reference_price(collateral_amount: u64, price_nad: u64) -> Result<u128> {
-    require!(price_nad > 0, ErrorCode::InsufficientLiquidity);
-    (collateral_amount as u128)
-        .checked_mul(price_nad as u128)
-        .and_then(|value| value.checked_div(NAD as u128))
-        .ok_or(ErrorCode::DebtMathOverflow.into())
-}
-
 fn collateral_amount_for_debt_at_reference_price(
     debt_amount: u64,
     price_nad: u64,
@@ -579,39 +575,6 @@ fn collateral_amount_for_debt_at_reference_price(
     )
     .ok_or(ErrorCode::DebtMathOverflow)?;
     u64::try_from(collateral_amount).map_err(|_| ErrorCode::DebtMathOverflow.into())
-}
-
-fn max_debt_repayable_by_collateral(
-    collateral_amount: u64,
-    price_nad: u64,
-    penalty_bps: u16,
-) -> Result<u64> {
-    let collateral_value = collateral_value_at_reference_price(collateral_amount, price_nad)?;
-    let repay_amount = collateral_value
-        .checked_mul(BPS_DENOMINATOR as u128)
-        .and_then(|value| value.checked_div((BPS_DENOMINATOR + penalty_bps) as u128))
-        .ok_or(ErrorCode::DebtMathOverflow)?;
-    u64::try_from(repay_amount).map_err(|_| ErrorCode::DebtMathOverflow.into())
-}
-
-fn validate_liquidation_progress(
-    is_insolvent: bool,
-    shares_to_reduce: u128,
-    debt_to_reduce: u64,
-    repay_amount: u64,
-) -> Result<()> {
-    require!(shares_to_reduce > 0, ErrorCode::ZeroDebtAmount);
-
-    if is_insolvent {
-        // Insolvent cleanup must still be able to clear bad debt when the
-        // remaining collateral has zero repayable value after integer pricing.
-        return Ok(());
-    }
-
-    require!(debt_to_reduce > 0, ErrorCode::ZeroDebtAmount);
-    require!(repay_amount > 0, ErrorCode::InsufficientDebt);
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -654,35 +617,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn max_repayable_by_collateral_reserves_total_penalty() {
-        assert_eq!(
-            max_debt_repayable_by_collateral(103, NAD, LIQUIDATION_PENALTY_BPS).unwrap(),
-            100
-        );
-    }
-
-    #[test]
-    fn zero_value_insolvent_collateral_can_be_cleaned_up() {
-        assert_eq!(collateral_value_at_reference_price(1, 1).unwrap(), 0);
-        assert_eq!(
-            max_debt_repayable_by_collateral(1, 1, LIQUIDATION_PENALTY_BPS).unwrap(),
-            0
-        );
-        assert!(validate_liquidation_progress(true, 1, 1, 0).is_ok());
-    }
-
-    #[test]
-    fn insolvent_dust_shares_can_be_cleaned_up_without_nominal_debt() {
-        assert!(validate_liquidation_progress(true, 1, 0, 0).is_ok());
-    }
-
-    #[test]
-    fn solvent_zero_amount_liquidation_is_rejected() {
-        let err = validate_liquidation_progress(false, 1, 0, 0).unwrap_err();
-        assert_eq!(err, error!(ErrorCode::ZeroDebtAmount));
-
-        let err = validate_liquidation_progress(false, 1, 1, 0).unwrap_err();
-        assert_eq!(err, error!(ErrorCode::InsufficientDebt));
-    }
 }

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -1,24 +1,28 @@
-use anchor_lang::prelude::*;
-use std::cmp::min;
-use anchor_spl::{
-    token::{Token, TokenAccount, Mint},
-    token_interface::{Token2022},
-};
 use crate::{
-    state::pair::Pair,
-    state::rate_model::RateModel,
-    state::futarchy_authority::FutarchyAuthority,
     constants::*,
     errors::ErrorCode,
-    events::{AdjustDebtEvent, EventMetadata, SwapEvent, UserPositionLiquidatedEvent, UserPositionUpdatedEvent},
-    state::user_position::{UserPosition, DebtDecreaseReason},
-    utils::{
-        token::{transfer_from_vault_to_user, transfer_from_vault_to_vault}, 
-        math::ceil_div,
-        gamm_math::{CPCurve, construct_virtual_reserves_at_pessimistic_price},
+    events::{
+        AdjustDebtEvent, EventMetadata, SwapEvent, UserPositionLiquidatedEvent,
+        UserPositionUpdatedEvent,
     },
     generate_gamm_pair_seeds,
+    state::futarchy_authority::FutarchyAuthority,
+    state::pair::Pair,
+    state::rate_model::RateModel,
+    state::user_position::{DebtDecreaseReason, UserPosition},
+    utils::{
+        math::ceil_div,
+        token::{
+            transfer_from_user_to_vault, transfer_from_vault_to_user, transfer_from_vault_to_vault,
+        },
+    },
 };
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    token::{Mint, Token, TokenAccount},
+    token_interface::Token2022,
+};
+use std::cmp::min;
 
 #[event_cpi]
 #[derive(Accounts)]
@@ -79,7 +83,30 @@ pub struct Liquidate<'info> {
         constraint = collateral_token_mint.key() == pair.token0 || collateral_token_mint.key() == pair.token1 @ ErrorCode::InvalidVault
     )]
     pub collateral_token_mint: Box<Account<'info, Mint>>,
-    
+
+    #[account(
+        constraint = debt_token_mint.key() == pair.get_debt_token(&collateral_token_mint.key()) @ ErrorCode::InvalidMint
+    )]
+    pub debt_token_mint: Box<Account<'info, Mint>>,
+
+    #[account(
+        mut,
+        seeds = [
+            RESERVE_VAULT_SEED_PREFIX,
+            pair.key().as_ref(),
+            debt_token_mint.key().as_ref(),
+        ],
+        bump = pair.get_reserve_vault_bump(&debt_token_mint.key())
+    )]
+    pub debt_reserve_vault: Box<Account<'info, TokenAccount>>,
+
+    #[account(
+        mut,
+        constraint = liquidator_debt_token_account.mint == debt_token_mint.key() @ ErrorCode::InvalidTokenAccount,
+        constraint = liquidator_debt_token_account.owner == payer.key() @ ErrorCode::InvalidTokenAccount,
+    )]
+    pub liquidator_debt_token_account: Box<Account<'info, TokenAccount>>,
+
     #[account(
         mut,
         seeds = [
@@ -89,7 +116,7 @@ pub struct Liquidate<'info> {
         ],
         bump = pair.get_reserve_vault_bump(&collateral_token_mint.key())
     )]
-    pub reserve_vault: Box<Account<'info, TokenAccount>>,
+    pub collateral_reserve_vault: Box<Account<'info, TokenAccount>>,
 
     /// CHECK: This is the owner of the position being liquidated.
     #[account(address = user_position.owner)]
@@ -104,22 +131,17 @@ impl<'info> Liquidate<'info> {
     pub fn validate(&self) -> Result<()> {
         let user_position = &self.user_position;
 
-        require!(user_position.is_initialized(), ErrorCode::UserPositionNotInitialized);
-        
+        require!(
+            user_position.is_initialized(),
+            ErrorCode::UserPositionNotInitialized
+        );
+
         // Check if user has enough debt
         match self.collateral_token_mint.key() == self.pair.token0 {
-            true => require_gt!(
-                user_position.debt1_shares,
-                0,
-                ErrorCode::ZeroDebtAmount
-            ),
-            false => require_gt!(
-                user_position.debt0_shares,
-                0,
-                ErrorCode::ZeroDebtAmount
-            ),
+            true => require_gt!(user_position.debt1_shares, 0, ErrorCode::ZeroDebtAmount),
+            false => require_gt!(user_position.debt0_shares, 0, ErrorCode::ZeroDebtAmount),
         }
-        
+
         Ok(())
     }
 
@@ -145,7 +167,10 @@ impl<'info> Liquidate<'info> {
             collateral_vault,
             caller_token_account,
             collateral_token_mint,
-            reserve_vault,
+            debt_token_mint,
+            debt_reserve_vault,
+            liquidator_debt_token_account,
+            collateral_reserve_vault,
             position_owner,
             payer,
             user_position,
@@ -154,7 +179,7 @@ impl<'info> Liquidate<'info> {
             ..
         } = ctx.accounts;
         let pair = &mut ctx.accounts.pair;
-        
+
         // Validate collateral vault and pool vault - already validated by Anchor seeds
         require_keys_eq!(
             collateral_vault.mint,
@@ -162,88 +187,107 @@ impl<'info> Liquidate<'info> {
             ErrorCode::InvalidVault
         );
         require_keys_eq!(
-            reserve_vault.mint,
+            debt_reserve_vault.mint,
+            debt_token_mint.key(),
+            ErrorCode::InvalidVault
+        );
+        require_keys_eq!(
+            debt_reserve_vault.owner,
+            pair.key(),
+            ErrorCode::InvalidVault
+        );
+        require_keys_eq!(
+            collateral_reserve_vault.mint,
             collateral_token_mint.key(),
             ErrorCode::InvalidVault
         );
         require_keys_eq!(
-            reserve_vault.owner,
+            collateral_reserve_vault.owner,
             pair.key(),
             ErrorCode::InvalidVault
         );
 
         let collateral_token = collateral_token_mint.key();
-        let debt_token = if collateral_token == pair.token0 { pair.token1 } else { pair.token0 };
+        let debt_token = debt_token_mint.key();
+        require_keys_eq!(
+            debt_token,
+            pair.get_debt_token(&collateral_token),
+            ErrorCode::InvalidMint
+        );
         let is_collateral_token0 = collateral_token == pair.token0;
         let liquidation_cf_bps = user_position.get_liquidation_cf_bps(pair, &debt_token)?;
         let k0 = pair.k(); // k before liquidation
 
         // Compute debt
         let (
-            user_debt, 
-            debt_reserve, 
-            user_collateral, 
-            collateral_reserve, 
-            collateral_ema_nad
-        )  = match is_collateral_token0 {
+            user_debt,
+            user_collateral,
+            collateral_ema_nad,
+            user_debt_shares,
+            total_debt,
+            total_debt_shares,
+        ) = match is_collateral_token0 {
             true => (
                 // collateral is token0, debt is token1
                 user_position.calculate_debt1(pair.total_debt1, pair.total_debt1_shares)?,
-                pair.reserve1, 
-                user_position.collateral0, 
-                pair.reserve0, 
-                pair.ema_price0_nad()
+                user_position.collateral0,
+                pair.ema_price0_nad(),
+                user_position.debt1_shares,
+                pair.total_debt1,
+                pair.total_debt1_shares,
             ),
             false => (
                 // collateral is token1, debt is token0
                 user_position.calculate_debt0(pair.total_debt0, pair.total_debt0_shares)?,
-                pair.reserve0,
-                user_position.collateral1, 
-                pair.reserve1, 
-                pair.ema_price1_nad()
+                user_position.collateral1,
+                pair.ema_price1_nad(),
+                user_position.debt0_shares,
+                pair.total_debt0,
+                pair.total_debt0_shares,
             ),
         };
 
-        // Construct virtual reserves at pessimistic price
-        let (collateral_ema_reserve, debt_ema_reserve) = construct_virtual_reserves_at_pessimistic_price(
-            collateral_reserve, debt_reserve, collateral_ema_nad, collateral_ema_nad
-        )?;
+        require!(collateral_ema_nad > 0, ErrorCode::InsufficientLiquidity);
 
-        // Collateral value with impact: debt coverable by selling all collateral
-        let collateral_value_with_impact = CPCurve::calculate_amount_out(collateral_ema_reserve, debt_ema_reserve, user_collateral)?;
-        
+        // Reference-price collateral value in debt-token units. This deliberately
+        // avoids AMM depth/price-impact valuation so LP withdrawals do not move
+        // liquidation eligibility through reserve depth alone.
+        let collateral_value =
+            collateral_value_at_reference_price(user_collateral, collateral_ema_nad)?;
+
         // Borrow limit = collateral_value * liquidation_cf
-        let borrow_limit = (collateral_value_with_impact as u128)
-            .checked_mul(liquidation_cf_bps as u128).ok_or(ErrorCode::DebtMathOverflow)?
-            .checked_div(BPS_DENOMINATOR as u128).ok_or(ErrorCode::DebtMathOverflow)?;
+        let borrow_limit = collateral_value
+            .checked_mul(liquidation_cf_bps as u128)
+            .ok_or(ErrorCode::DebtMathOverflow)?
+            .checked_div(BPS_DENOMINATOR as u128)
+            .ok_or(ErrorCode::DebtMathOverflow)?;
 
         // Position is liquidatable if debt >= borrow_limit
-        require_gte!(user_debt as u128, borrow_limit, ErrorCode::NotUndercollateralized);
- 
-        // Health Factor (HF) < 1: undercollateralized (liquidatable)
-        // collateral_value > user_debt > borrow_limit: position can be liquidated partially
-        // user_debt > collateral_value: insolvent (bad debt, collateral can't cover principal)
-        // If insolvent, writeoff all debt; else, writeoff a portion using close factor (partial liquidation)
-        let is_insolvent = user_debt > collateral_value_with_impact;
+        require_gte!(
+            user_debt as u128,
+            borrow_limit,
+            ErrorCode::NotUndercollateralized
+        );
 
-        // Get user's debt shares for the debt token
-        let (user_debt_shares, total_debt, total_debt_shares) = match is_collateral_token0 {
-            true => (user_position.debt1_shares, pair.total_debt1, pair.total_debt1_shares),
-            false => (user_position.debt0_shares, pair.total_debt0, pair.total_debt0_shares),
-        };
+        // If debt exceeds reference collateral value, close the position and
+        // socialize only the uncovered portion after the liquidator repays the
+        // maximum debt value supportable by the seized collateral.
+        let is_insolvent = (user_debt as u128) > collateral_value;
 
-        // Calculate shares to writeoff first
+        // Calculate shares to reduce first
         // For partial liquidation: ceil(user_debt_shares * CLOSE_FACTOR_BPS / BPS_DENOMINATOR)
         // For insolvent positions: all user debt shares
-        let shares_to_writeoff: u128 = match is_insolvent {
+        let shares_to_reduce: u128 = match is_insolvent {
             true => user_debt_shares,
             false => {
                 // ceiled division to avoid edge case where small shares never get fully written off
                 let partial_shares = ceil_div(
                     user_debt_shares
-                        .checked_mul(CLOSE_FACTOR_BPS as u128).ok_or(ErrorCode::DebtMathOverflow)?,
-                    BPS_DENOMINATOR as u128
-                ).ok_or(ErrorCode::DebtMathOverflow)?;
+                        .checked_mul(CLOSE_FACTOR_BPS as u128)
+                        .ok_or(ErrorCode::DebtMathOverflow)?,
+                    BPS_DENOMINATOR as u128,
+                )
+                .ok_or(ErrorCode::DebtMathOverflow)?;
                 min(user_debt_shares, partial_shares) // clamped to user's shares
             }
         };
@@ -251,34 +295,52 @@ impl<'info> Liquidate<'info> {
         // Use floor division for debt to ensure shares drain faster than debt.
         // This prevents orphaned user shares when total_debt hits 0 first (ceil/ceil problem).
         // Instead, total_shares hits 0 first, leaving orphaned debt which the sync reset safely clears.
-        let debt_to_writeoff: u64 = match total_debt_shares == 0 {
+        let debt_to_reduce: u64 = match total_debt_shares == 0 {
             true => 0,
             false => {
-                let debt = shares_to_writeoff
-                    .checked_mul(total_debt as u128).ok_or(ErrorCode::DebtMathOverflow)?
-                    .checked_div(total_debt_shares).ok_or(ErrorCode::DebtMathOverflow)?;
+                let debt = shares_to_reduce
+                    .checked_mul(total_debt as u128)
+                    .ok_or(ErrorCode::DebtMathOverflow)?
+                    .checked_div(total_debt_shares)
+                    .ok_or(ErrorCode::DebtMathOverflow)?;
                 min(user_debt, debt as u64) // clamped to user's debt
             }
         };
-        
-        // Calculate base collateral to seize with price impact: Δx = Δy * x / (y - Δy)
-        let collateral_base = match is_insolvent {
-            true => user_collateral,
-            false => CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_to_writeoff)?,
+        require!(debt_to_reduce > 0, ErrorCode::ZeroDebtAmount);
+
+        let max_repay_from_collateral = max_debt_repayable_by_collateral(
+            user_collateral,
+            collateral_ema_nad,
+            LIQUIDATION_PENALTY_BPS,
+        )?;
+        let repay_amount = match is_insolvent {
+            true => min(debt_to_reduce, max_repay_from_collateral),
+            false => debt_to_reduce,
         };
+        require!(repay_amount > 0, ErrorCode::InsufficientDebt);
+        require_gte!(
+            liquidator_debt_token_account.amount,
+            repay_amount,
+            ErrorCode::InsufficientBalance
+        );
 
-        // Add liquidation penalty on top (paid by borrower, benefits LPs)
-        // total_seized = base * (1 + LIQUIDATION_PENALTY_BPS / BPS)
-        let collateral_with_penalty = ceil_div(
-            (collateral_base as u128)
-                .checked_mul((BPS_DENOMINATOR + LIQUIDATION_PENALTY_BPS) as u128)
-                .ok_or(ErrorCode::DebtMathOverflow)?,
-            BPS_DENOMINATOR as u128
-        ).ok_or(ErrorCode::DebtMathOverflow)?;
+        // Base collateral covers the repaid debt at the EMA reference price.
+        let collateral_base =
+            collateral_amount_for_debt_at_reference_price(repay_amount, collateral_ema_nad, 0)?;
 
-        // Clamp to what user actually has
-        let collateral_final: u64 = min(collateral_with_penalty, user_collateral as u128)
-            .try_into().map_err(|_| ErrorCode::DebtMathOverflow)?;
+        // Total collateral seized includes the full liquidation penalty. In the
+        // insolvent path all collateral is exhausted before any loss is socialized.
+        let collateral_final = match is_insolvent {
+            true => user_collateral,
+            false => {
+                let collateral_with_penalty = collateral_amount_for_debt_at_reference_price(
+                    repay_amount,
+                    collateral_ema_nad,
+                    LIQUIDATION_PENALTY_BPS,
+                )?;
+                min(collateral_with_penalty, user_collateral)
+            }
+        };
 
         let collateral_token = pair.get_collateral_token(&debt_token);
         let collateral_amount_pre_liquidation = match collateral_token == pair.token0 {
@@ -289,39 +351,70 @@ impl<'info> Liquidate<'info> {
         let collateral_amount_post_liquidation = collateral_amount_pre_liquidation
             .checked_sub(collateral_final)
             .ok_or(ErrorCode::DebtMathOverflow)?;
-        let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(&pair, &collateral_token, collateral_amount_post_liquidation)?;
+        let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(
+            &pair,
+            &collateral_token,
+            collateral_amount_post_liquidation,
+        )?;
 
-        // Liquidator incentive from base amount (not from penalty)
-        let caller_incentive: u64 = min(
-            (collateral_base as u128)
-                .checked_mul(LIQUIDATION_INCENTIVE_BPS as u128).ok_or(ErrorCode::DebtMathOverflow)?
-                .checked_div(BPS_DENOMINATOR as u128).ok_or(ErrorCode::DebtMathOverflow)?
-                .try_into().map_err(|_| ErrorCode::DebtMathOverflow)?,
-            collateral_final
+        // Liquidator receives repaid-debt collateral value plus the incentive.
+        let collateral_to_liquidator = min(
+            collateral_amount_for_debt_at_reference_price(
+                repay_amount,
+                collateral_ema_nad,
+                LIQUIDATION_INCENTIVE_BPS,
+            )?,
+            collateral_final,
         );
-        
-        // Remaining collateral goes to reserves (LPs get base + penalty - incentive)
+
+        // Remaining collateral goes to reserves as the LP-side penalty.
         let collateral_to_reserves = collateral_final
-            .checked_sub(caller_incentive)
+            .checked_sub(collateral_to_liquidator)
             .ok_or(ErrorCode::DebtMathOverflow)?;
+        let liquidation_bonus = collateral_to_liquidator.saturating_sub(collateral_base);
 
+        let debt_token_program = match debt_token_mint.to_account_info().owner == token_program.key
+        {
+            true => token_program.to_account_info(),
+            false => token_2022_program.to_account_info(),
+        };
+        let collateral_token_program =
+            match collateral_token_mint.to_account_info().owner == token_program.key {
+                true => token_program.to_account_info(),
+                false => token_2022_program.to_account_info(),
+            };
 
-        // Pass exact shares to writeoff to avoid edge cases where floor division leaves residual shares
-        user_position.decrease_debt(pair, &debt_token, debt_to_writeoff, DebtDecreaseReason::WriteOff(shares_to_writeoff))?;
+        transfer_from_user_to_vault(
+            payer.to_account_info(),
+            liquidator_debt_token_account.to_account_info(),
+            debt_reserve_vault.to_account_info(),
+            debt_token_mint.to_account_info(),
+            debt_token_program,
+            repay_amount,
+            debt_token_mint.decimals,
+        )?;
+
+        // Pass exact shares to avoid edge cases where floor division leaves residual shares.
+        user_position.decrease_debt(
+            pair,
+            &debt_token,
+            debt_to_reduce,
+            DebtDecreaseReason::LiquidationRepayment {
+                exact_shares: shares_to_reduce,
+                cash_credit: repay_amount,
+            },
+        )?;
         user_position.set_liquidation_cf_for_debt_token(&debt_token, &pair, liquidation_cf_bps);
 
-        // Transfer liquidation incentive to caller from collateral vault
-        if caller_incentive > 0 {
+        // Transfer seized collateral to caller from collateral vault.
+        if collateral_to_liquidator > 0 {
             transfer_from_vault_to_user(
                 pair.to_account_info(),
                 collateral_vault.to_account_info(),
                 caller_token_account.to_account_info(),
                 collateral_token_mint.to_account_info(),
-                match collateral_token_mint.to_account_info().owner == token_program.key {
-                    true => token_program.to_account_info(),
-                    false => token_2022_program.to_account_info(),
-                },
-                caller_incentive,
+                collateral_token_program.clone(),
+                collateral_to_liquidator,
                 collateral_token_mint.decimals,
                 &[&generate_gamm_pair_seeds!(pair)[..]],
             )?;
@@ -331,12 +424,9 @@ impl<'info> Liquidate<'info> {
         transfer_from_vault_to_vault(
             pair.to_account_info(),
             collateral_vault.to_account_info(),
-            reserve_vault.to_account_info(),
+            collateral_reserve_vault.to_account_info(),
             collateral_token_mint.to_account_info(),
-            match collateral_token_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
+            collateral_token_program,
             collateral_to_reserves,
             collateral_token_mint.decimals,
             &[&generate_gamm_pair_seeds!(pair)[..]],
@@ -346,15 +436,27 @@ impl<'info> Liquidate<'info> {
         // Subtract the full seized amount from user position
         match is_collateral_token0 {
             true => {
-                user_position.collateral0 = user_position.collateral0.checked_sub(collateral_final).unwrap();
-                pair.total_collateral0 = pair.total_collateral0.checked_sub(collateral_final).unwrap();
+                user_position.collateral0 = user_position
+                    .collateral0
+                    .checked_sub(collateral_final)
+                    .unwrap();
+                pair.total_collateral0 = pair
+                    .total_collateral0
+                    .checked_sub(collateral_final)
+                    .unwrap();
                 // Add remaining collateral (after incentive) to reserves
                 pair.reserve0 = pair.reserve0.checked_add(collateral_to_reserves).unwrap();
                 pair.cash_reserve0 = pair.cash_reserve0.saturating_add(collateral_to_reserves);
             }
             false => {
-                user_position.collateral1 = user_position.collateral1.checked_sub(collateral_final).unwrap();
-                pair.total_collateral1 = pair.total_collateral1.checked_sub(collateral_final).unwrap();
+                user_position.collateral1 = user_position
+                    .collateral1
+                    .checked_sub(collateral_final)
+                    .unwrap();
+                pair.total_collateral1 = pair
+                    .total_collateral1
+                    .checked_sub(collateral_final)
+                    .unwrap();
                 // Add remaining collateral (after incentive) to reserves
                 pair.reserve1 = pair.reserve1.checked_add(collateral_to_reserves).unwrap();
                 pair.cash_reserve1 = pair.cash_reserve1.saturating_add(collateral_to_reserves);
@@ -365,19 +467,19 @@ impl<'info> Liquidate<'info> {
             metadata: EventMetadata::new(payer.key(), pair.key()),
             reserve0: pair.reserve0,
             reserve1: pair.reserve1,
-            is_token0_in: is_collateral_token0,
-            amount_in: collateral_to_reserves,
-            amount_out: debt_to_writeoff,
-            amount_in_after_fee: collateral_to_reserves,
+            is_token0_in: debt_token == pair.token0,
+            amount_in: repay_amount,
+            amount_out: collateral_to_liquidator,
+            amount_in_after_fee: repay_amount,
             lp_fee: 0,
             protocol_fee: 0,
         });
 
-        // Emit debt adjustment event (debt written off)
+        // Emit debt adjustment event (debt repaid and possibly socialized if insolvent)
         let (amount0, amount1) = if is_collateral_token0 {
-            (0, -(debt_to_writeoff as i64))
+            (0, -(debt_to_reduce as i64))
         } else {
-            (-(debt_to_writeoff as i64), 0)
+            (-(debt_to_reduce as i64), 0)
         };
         emit_cpi!(AdjustDebtEvent {
             metadata: EventMetadata::new(position_owner.key(), pair.key()),
@@ -403,17 +505,130 @@ impl<'info> Liquidate<'info> {
             metadata: EventMetadata::new(position_owner.key(), pair.key()),
             position: user_position.key(),
             liquidator: payer.key(),
-            collateral0_liquidated: if is_collateral_token0 { collateral_final } else { 0 },
-            collateral1_liquidated: if is_collateral_token0 { 0 } else { collateral_final },
-            debt0_liquidated: if is_collateral_token0 { 0 } else { debt_to_writeoff },
-            debt1_liquidated: if is_collateral_token0 { debt_to_writeoff } else { 0 },
-            collateral_price: if is_collateral_token0 { pair.ema_price0_nad() } else { pair.ema_price1_nad() },
-            shortfall: if is_insolvent { (user_debt as u128).saturating_sub(collateral_value_with_impact as u128) } else { 0 },
-            liquidation_bonus_applied: caller_incentive,
+            collateral0_liquidated: if is_collateral_token0 {
+                collateral_final
+            } else {
+                0
+            },
+            collateral1_liquidated: if is_collateral_token0 {
+                0
+            } else {
+                collateral_final
+            },
+            debt0_liquidated: if is_collateral_token0 {
+                0
+            } else {
+                debt_to_reduce
+            },
+            debt1_liquidated: if is_collateral_token0 {
+                debt_to_reduce
+            } else {
+                0
+            },
+            collateral_price: if is_collateral_token0 {
+                pair.ema_price0_nad()
+            } else {
+                pair.ema_price1_nad()
+            },
+            shortfall: debt_to_reduce.saturating_sub(repay_amount) as u128,
+            liquidation_bonus_applied: liquidation_bonus,
             k0: k0,
             k1: pair.k(),
         });
 
         Ok(())
+    }
+}
+
+fn collateral_value_at_reference_price(collateral_amount: u64, price_nad: u64) -> Result<u128> {
+    require!(price_nad > 0, ErrorCode::InsufficientLiquidity);
+    (collateral_amount as u128)
+        .checked_mul(price_nad as u128)
+        .and_then(|value| value.checked_div(NAD as u128))
+        .ok_or(ErrorCode::DebtMathOverflow.into())
+}
+
+fn collateral_amount_for_debt_at_reference_price(
+    debt_amount: u64,
+    price_nad: u64,
+    penalty_bps: u16,
+) -> Result<u64> {
+    require!(price_nad > 0, ErrorCode::InsufficientLiquidity);
+    let debt_with_penalty = ceil_div(
+        (debt_amount as u128)
+            .checked_mul((BPS_DENOMINATOR + penalty_bps) as u128)
+            .ok_or(ErrorCode::DebtMathOverflow)?,
+        BPS_DENOMINATOR as u128,
+    )
+    .ok_or(ErrorCode::DebtMathOverflow)?;
+    let collateral_amount = ceil_div(
+        debt_with_penalty
+            .checked_mul(NAD as u128)
+            .ok_or(ErrorCode::DebtMathOverflow)?,
+        price_nad as u128,
+    )
+    .ok_or(ErrorCode::DebtMathOverflow)?;
+    u64::try_from(collateral_amount).map_err(|_| ErrorCode::DebtMathOverflow.into())
+}
+
+fn max_debt_repayable_by_collateral(
+    collateral_amount: u64,
+    price_nad: u64,
+    penalty_bps: u16,
+) -> Result<u64> {
+    let collateral_value = collateral_value_at_reference_price(collateral_amount, price_nad)?;
+    let repay_amount = collateral_value
+        .checked_mul(BPS_DENOMINATOR as u128)
+        .and_then(|value| value.checked_div((BPS_DENOMINATOR + penalty_bps) as u128))
+        .ok_or(ErrorCode::DebtMathOverflow)?;
+    u64::try_from(repay_amount).map_err(|_| ErrorCode::DebtMathOverflow.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reference_price_amounts_apply_liquidation_penalty() {
+        assert_eq!(
+            collateral_amount_for_debt_at_reference_price(100, NAD, 0).unwrap(),
+            100
+        );
+        assert_eq!(
+            collateral_amount_for_debt_at_reference_price(100, NAD, LIQUIDATION_INCENTIVE_BPS)
+                .unwrap(),
+            101
+        );
+        assert_eq!(
+            collateral_amount_for_debt_at_reference_price(100, NAD, LIQUIDATION_PENALTY_BPS)
+                .unwrap(),
+            103
+        );
+    }
+
+    #[test]
+    fn reference_price_amounts_round_up_after_price_conversion() {
+        assert_eq!(
+            collateral_amount_for_debt_at_reference_price(100, NAD * 2, 0).unwrap(),
+            50
+        );
+        assert_eq!(
+            collateral_amount_for_debt_at_reference_price(100, NAD * 2, LIQUIDATION_INCENTIVE_BPS)
+                .unwrap(),
+            51
+        );
+        assert_eq!(
+            collateral_amount_for_debt_at_reference_price(100, NAD * 2, LIQUIDATION_PENALTY_BPS)
+                .unwrap(),
+            52
+        );
+    }
+
+    #[test]
+    fn max_repayable_by_collateral_reserves_total_penalty() {
+        assert_eq!(
+            max_debt_repayable_by_collateral(103, NAD, LIQUIDATION_PENALTY_BPS).unwrap(),
+            100
+        );
     }
 }

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -249,9 +249,19 @@ impl<'info> Liquidate<'info> {
 
         require!(collateral_ema_nad > 0, ErrorCode::InsufficientLiquidity);
 
-        // Reference-price collateral value in debt-token units. This deliberately
-        // avoids AMM depth/price-impact valuation so LP withdrawals do not move
-        // liquidation eligibility through reserve depth alone.
+        // Reference-price collateral value in debt-token units.
+        //
+        // Liquidation deliberately uses the symmetric EMA, not the directional EMA:
+        // snapping liquidation down to the latest lower spot would let an attacker
+        // dump the pool price and immediately liquidate otherwise healthy borrowers.
+        //
+        // Borrow, collateral removal, and liquidity removal use the directional EMA
+        // as an anti-front-running control for user-initiated risk increases. That
+        // check prevents borrowing/removing against a stale high EMA when spot has
+        // already fallen; it is not meant to be a liquidation trigger.
+        //
+        // This also avoids AMM depth/price-impact valuation so LP withdrawals do
+        // not move liquidation eligibility through reserve depth alone.
         let collateral_value =
             collateral_value_at_reference_price(user_collateral, collateral_ema_nad)?;
 

--- a/programs/omnipair/src/instructions/lending/liquidate.rs
+++ b/programs/omnipair/src/instructions/lending/liquidate.rs
@@ -262,7 +262,10 @@ impl<'info> Liquidate<'info> {
         };
         
         // Calculate base collateral to seize with price impact: Δx = Δy * x / (y - Δy)
-        let collateral_base = CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_to_writeoff)?;
+        let collateral_base = match is_insolvent {
+            true => user_collateral,
+            false => CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_to_writeoff)?,
+        };
 
         // Add liquidation penalty on top (paid by borrower, benefits LPs)
         // total_seized = base * (1 + LIQUIDATION_PENALTY_BPS / BPS)

--- a/programs/omnipair/src/instructions/lending/mod.rs
+++ b/programs/omnipair/src/instructions/lending/mod.rs
@@ -5,7 +5,9 @@ pub mod borrow;
 pub mod repay;
 pub mod liquidate;
 pub mod flashloan;
+pub mod transfer_user_position;
 
 pub use common::*;
 pub use liquidate::*;
 pub use flashloan::*;
+pub use transfer_user_position::*;

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -146,9 +146,6 @@ impl<'info> CommonAdjustCollateral<'info> {
         } else {
             user_position.collateral1
         };
-        // Removing collateral is a user-initiated risk increase, so refresh the
-        // liquidation CF through the pessimistic directional EMA path. Liquidation
-        // itself uses symmetric EMA to avoid dump-spot-and-liquidate attacks.
         let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(&pair, &collateral_token, collateral_amount)?;
         user_position.set_liquidation_cf_for_debt_token(&debt_token, &pair, liquidation_cf_bps);
 

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -1,18 +1,18 @@
-use anchor_lang::prelude::*;
 use crate::{
     constants::PAIR_SEED_PREFIX,
     errors::ErrorCode,
     events::{AdjustCollateralEvent, EventMetadata, UserPositionUpdatedEvent},
-    utils::token::transfer_from_vault_to_user,
-    utils::liquidity_delta_circuit_breaker::require_no_same_tx_liquidity_delta,
     generate_gamm_pair_seeds,
-    instructions::lending::common::{CommonAdjustCollateral, AdjustCollateralArgs},
+    instructions::lending::common::{AdjustCollateralArgs, CommonAdjustCollateral},
+    utils::liquidity_delta_circuit_breaker::require_no_same_tx_liquidity_delta,
+    utils::token::{token_program_for_mint, transfer_from_vault_to_user},
 };
+use anchor_lang::prelude::*;
 
 impl<'info> CommonAdjustCollateral<'info> {
     pub fn validate_remove(&self, args: &AdjustCollateralArgs) -> Result<()> {
         let AdjustCollateralArgs { amount } = args;
-        
+
         require_no_same_tx_liquidity_delta(
             &self.pair.key(),
             &self.instructions_sysvar.to_account_info(),
@@ -29,12 +29,19 @@ impl<'info> CommonAdjustCollateral<'info> {
 
         // Calculate current debt
         let debt = match is_collateral_token0 {
-            true => self.user_position.calculate_debt1(self.pair.total_debt1, self.pair.total_debt1_shares)?,
-            false => self.user_position.calculate_debt0(self.pair.total_debt0, self.pair.total_debt0_shares)?,
+            true => self
+                .user_position
+                .calculate_debt1(self.pair.total_debt1, self.pair.total_debt1_shares)?,
+            false => self
+                .user_position
+                .calculate_debt0(self.pair.total_debt0, self.pair.total_debt0_shares)?,
         };
 
         // Check reduce-only mode: if active, user must have zero debt to remove collateral
-        if self.futarchy_authority.is_reduce_only(self.pair.reduce_only) {
+        if self
+            .futarchy_authority
+            .is_reduce_only(self.pair.reduce_only)
+        {
             require!(debt == 0, ErrorCode::ReduceOnlyHasDebt);
         }
 
@@ -56,19 +63,24 @@ impl<'info> CommonAdjustCollateral<'info> {
             let remaining_collateral = user_collateral
                 .checked_sub(withdraw_amount)
                 .ok_or(ErrorCode::Overflow)?;
-            let collateral_token = if is_collateral_token0 { self.pair.token0 } else { self.pair.token1 };
-            let (post_withdraw_borrow_limit, _, _) = self.pair.get_max_debt_and_cf_bps_for_collateral(
-                &self.pair,
-                &collateral_token,
-                remaining_collateral,
-            )?;
+            let collateral_token = if is_collateral_token0 {
+                self.pair.token0
+            } else {
+                self.pair.token1
+            };
+            let (post_withdraw_borrow_limit, _, _) =
+                self.pair.get_max_debt_and_cf_bps_for_collateral(
+                    &self.pair,
+                    &collateral_token,
+                    remaining_collateral,
+                )?;
             require_gte!(
                 post_withdraw_borrow_limit,
                 debt,
                 ErrorCode::BorrowingPowerExceeded
             );
         }
-        
+
         Ok(())
     }
 
@@ -118,10 +130,11 @@ impl<'info> CommonAdjustCollateral<'info> {
             collateral_vault.to_account_info(),
             user_collateral_token_account.to_account_info(),
             collateral_token_mint.to_account_info(),
-            match collateral_vault.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
+            token_program_for_mint(
+                &collateral_token_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
             withdraw_amount,
             collateral_token_mint.decimals,
             &[&generate_gamm_pair_seeds!(pair)[..]],
@@ -130,12 +143,20 @@ impl<'info> CommonAdjustCollateral<'info> {
         // Transfer tokens from vault to user
         match is_token0 {
             true => {
-                pair.total_collateral0 = pair.total_collateral0.checked_sub(withdraw_amount).unwrap();
-                user_position.collateral0 = user_position.collateral0.checked_sub(withdraw_amount).unwrap();
-            },
+                pair.total_collateral0 =
+                    pair.total_collateral0.checked_sub(withdraw_amount).unwrap();
+                user_position.collateral0 = user_position
+                    .collateral0
+                    .checked_sub(withdraw_amount)
+                    .unwrap();
+            }
             false => {
-                pair.total_collateral1 = pair.total_collateral1.checked_sub(withdraw_amount).unwrap();
-                user_position.collateral1 = user_position.collateral1.checked_sub(withdraw_amount).unwrap();
+                pair.total_collateral1 =
+                    pair.total_collateral1.checked_sub(withdraw_amount).unwrap();
+                user_position.collateral1 = user_position
+                    .collateral1
+                    .checked_sub(withdraw_amount)
+                    .unwrap();
             }
         }
 
@@ -146,7 +167,11 @@ impl<'info> CommonAdjustCollateral<'info> {
         } else {
             user_position.collateral1
         };
-        let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(&pair, &collateral_token, collateral_amount)?;
+        let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(
+            &pair,
+            &collateral_token,
+            collateral_amount,
+        )?;
         user_position.set_liquidation_cf_for_debt_token(&debt_token, &pair, liquidation_cf_bps);
 
         // Emit collateral adjustment event
@@ -154,13 +179,13 @@ impl<'info> CommonAdjustCollateral<'info> {
             true => (-(withdraw_amount as i64), 0),
             false => (0, -(withdraw_amount as i64)),
         };
-        
+
         emit_cpi!(AdjustCollateralEvent {
             metadata: EventMetadata::new(user.key(), pair.key()),
             amount0,
             amount1,
         });
-        
+
         // Emit position updated event
         emit_cpi!(UserPositionUpdatedEvent {
             metadata: EventMetadata::new(user.key(), pair.key()),
@@ -187,7 +212,11 @@ mod tests {
     };
     use crate::utils::math::ceil_div;
 
-    fn simulate_resolve_remove_collateral_amount(user_collateral: u64, debt: u64, amount: u64) -> u64 {
+    fn simulate_resolve_remove_collateral_amount(
+        user_collateral: u64,
+        debt: u64,
+        amount: u64,
+    ) -> u64 {
         if amount == u64::MAX && debt == 0 {
             user_collateral
         } else {
@@ -219,11 +248,8 @@ mod tests {
             max_cf_bps as u128,
         )
         .unwrap();
-        let min_collateral = ceil_div(
-            min_collateral_value * (NAD as u128),
-            ema_price as u128,
-        )
-        .unwrap();
+        let min_collateral =
+            ceil_div(min_collateral_value * (NAD as u128), ema_price as u128).unwrap();
         let min_collateral_u64 = u64::try_from(min_collateral).unwrap_or(u64::MAX);
 
         user_collateral.saturating_sub(min_collateral_u64)
@@ -348,8 +374,14 @@ mod tests {
 
     #[test]
     fn max_sentinel_only_resolves_to_all_collateral_without_debt() {
-        assert_eq!(simulate_resolve_remove_collateral_amount(123, 0, u64::MAX), 123);
-        assert_eq!(simulate_resolve_remove_collateral_amount(123, 1, u64::MAX), u64::MAX);
+        assert_eq!(
+            simulate_resolve_remove_collateral_amount(123, 0, u64::MAX),
+            123
+        );
+        assert_eq!(
+            simulate_resolve_remove_collateral_amount(123, 1, u64::MAX),
+            u64::MAX
+        );
         assert_eq!(simulate_resolve_remove_collateral_amount(123, 1, 10), 10);
     }
 

--- a/programs/omnipair/src/instructions/lending/remove_collateral.rs
+++ b/programs/omnipair/src/instructions/lending/remove_collateral.rs
@@ -146,6 +146,9 @@ impl<'info> CommonAdjustCollateral<'info> {
         } else {
             user_position.collateral1
         };
+        // Removing collateral is a user-initiated risk increase, so refresh the
+        // liquidation CF through the pessimistic directional EMA path. Liquidation
+        // itself uses symmetric EMA to avoid dump-spot-and-liquidate attacks.
         let (_, _, liquidation_cf_bps) = pair.get_max_debt_and_cf_bps_for_collateral(&pair, &collateral_token, collateral_amount)?;
         user_position.set_liquidation_cf_for_debt_token(&debt_token, &pair, liquidation_cf_bps);
 

--- a/programs/omnipair/src/instructions/lending/repay.rs
+++ b/programs/omnipair/src/instructions/lending/repay.rs
@@ -1,47 +1,49 @@
-use anchor_lang::prelude::*;
 use crate::{
     errors::ErrorCode,
-    events::{AdjustDebtEvent, UserPositionUpdatedEvent, EventMetadata},
-    utils::token::transfer_from_user_to_vault,
-    instructions::lending::common::{CommonAdjustDebt, AdjustDebtArgs},
+    events::{AdjustDebtEvent, EventMetadata, UserPositionUpdatedEvent},
+    instructions::lending::common::{AdjustDebtArgs, CommonAdjustDebt},
     state::user_position::DebtDecreaseReason,
+    utils::token::{amount_with_transfer_fee, token_program_for_mint, transfer_from_user_to_vault},
 };
+use anchor_lang::prelude::*;
 
 impl<'info> CommonAdjustDebt<'info> {
     pub fn validate_repay(&self, args: &AdjustDebtArgs) -> Result<()> {
         let AdjustDebtArgs { amount } = args;
-        
+
         require!(*amount > 0, ErrorCode::AmountZero);
 
         let is_repay_all = *amount == u64::MAX;
         let is_token0 = self.user_reserve_token_account.mint == self.pair.token0;
         let user_total_debt = match is_token0 {
-            true => self.user_position.calculate_debt0(self.pair.total_debt0, self.pair.total_debt0_shares)?,
-            false => self.user_position.calculate_debt1(self.pair.total_debt1, self.pair.total_debt1_shares)?,
+            true => self
+                .user_position
+                .calculate_debt0(self.pair.total_debt0, self.pair.total_debt0_shares)?,
+            false => self
+                .user_position
+                .calculate_debt1(self.pair.total_debt1, self.pair.total_debt1_shares)?,
         };
-        let debt_to_repay = if is_repay_all { user_total_debt } else { *amount };
-        
+        let debt_to_repay = if is_repay_all {
+            user_total_debt
+        } else {
+            *amount
+        };
+        let transfer_amount =
+            amount_with_transfer_fee(&self.reserve_token_mint.to_account_info(), debt_to_repay)?;
+
         // Check user token balance >= debt to repay
         require_gte!(
             self.user_reserve_token_account.amount,
-            debt_to_repay,
+            transfer_amount,
             ErrorCode::InsufficientBalance
         );
 
         // Check user debt >= debt to repay
-        require_gte!(
-            user_total_debt,
-            debt_to_repay,
-            ErrorCode::InsufficientDebt
-        );
-        
+        require_gte!(user_total_debt, debt_to_repay, ErrorCode::InsufficientDebt);
+
         // debt cannot be zero
-        require_gt!(
-            user_total_debt,
-            0,
-            ErrorCode::ZeroDebtAmount
-        );
-        
+        require_gt!(user_total_debt, 0, ErrorCode::ZeroDebtAmount);
+
         Ok(())
     }
 
@@ -66,10 +68,12 @@ impl<'info> CommonAdjustDebt<'info> {
 
         let is_repay_all = args.amount == u64::MAX;
         let is_token0 = user_reserve_token_account.mint == pair.token0;
-        let debt_to_repay = if is_repay_all { 
+        let debt_to_repay = if is_repay_all {
             match is_token0 {
                 true => user_position.calculate_debt0(pair.total_debt0, pair.total_debt0_shares)?,
-                false => user_position.calculate_debt1(pair.total_debt1, pair.total_debt1_shares)?,
+                false => {
+                    user_position.calculate_debt1(pair.total_debt1, pair.total_debt1_shares)?
+                }
             }
         } else {
             args.amount
@@ -81,16 +85,22 @@ impl<'info> CommonAdjustDebt<'info> {
             user_reserve_token_account.to_account_info(),
             reserve_vault.to_account_info(),
             reserve_token_mint.to_account_info(),
-            match reserve_token_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
-            debt_to_repay,
+            token_program_for_mint(
+                &reserve_token_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
+            amount_with_transfer_fee(&reserve_token_mint.to_account_info(), debt_to_repay)?,
             reserve_token_mint.decimals,
         )?;
 
         // Update debt
-        user_position.decrease_debt(pair, &reserve_token_mint.key(), debt_to_repay, DebtDecreaseReason::Repayment)?;
+        user_position.decrease_debt(
+            pair,
+            &reserve_token_mint.key(),
+            debt_to_repay,
+            DebtDecreaseReason::Repayment,
+        )?;
 
         // Emit event
         let (amount0, amount1) = if user_reserve_token_account.mint == pair.token0 {
@@ -98,7 +108,7 @@ impl<'info> CommonAdjustDebt<'info> {
         } else {
             (0, -(debt_to_repay as i64))
         };
-        
+
         emit_cpi!(AdjustDebtEvent {
             metadata: EventMetadata::new(user.key(), pair.key()),
             amount0,

--- a/programs/omnipair/src/instructions/lending/transfer_user_position.rs
+++ b/programs/omnipair/src/instructions/lending/transfer_user_position.rs
@@ -68,7 +68,10 @@ impl<'info> TransferUserPosition<'info> {
             ErrorCode::InvalidPositionOwner
         );
         require!(
-            self.to_position.is_empty(),
+            self.to_position.collateral0 == 0
+                && self.to_position.collateral1 == 0
+                && self.to_position.debt0_shares == 0
+                && self.to_position.debt1_shares == 0,
             ErrorCode::RecipientPositionNotEmpty
         );
 
@@ -81,14 +84,30 @@ impl<'info> TransferUserPosition<'info> {
         let pair_key = ctx.accounts.pair.key();
         let current_owner_key = ctx.accounts.current_owner.key();
         let new_owner_key = ctx.accounts.new_owner.key();
+        let from_position_bump = ctx.accounts.from_position.bump;
         let to_position_bump = ctx.bumps.to_position;
 
-        ctx.accounts.from_position.transfer_to(
-            &mut ctx.accounts.to_position,
-            new_owner_key,
-            pair_key,
-            to_position_bump,
-        )?;
+        ctx.accounts.to_position.owner = new_owner_key;
+        ctx.accounts.to_position.pair = pair_key;
+        ctx.accounts.to_position.collateral0_liquidation_cf_bps =
+            ctx.accounts.from_position.collateral0_liquidation_cf_bps;
+        ctx.accounts.to_position.collateral1_liquidation_cf_bps =
+            ctx.accounts.from_position.collateral1_liquidation_cf_bps;
+        ctx.accounts.to_position.collateral0 = ctx.accounts.from_position.collateral0;
+        ctx.accounts.to_position.collateral1 = ctx.accounts.from_position.collateral1;
+        ctx.accounts.to_position.debt0_shares = ctx.accounts.from_position.debt0_shares;
+        ctx.accounts.to_position.debt1_shares = ctx.accounts.from_position.debt1_shares;
+        ctx.accounts.to_position.bump = to_position_bump;
+
+        ctx.accounts.from_position.owner = Pubkey::default();
+        ctx.accounts.from_position.pair = Pubkey::default();
+        ctx.accounts.from_position.collateral0_liquidation_cf_bps = 0;
+        ctx.accounts.from_position.collateral1_liquidation_cf_bps = 0;
+        ctx.accounts.from_position.collateral0 = 0;
+        ctx.accounts.from_position.collateral1 = 0;
+        ctx.accounts.from_position.debt0_shares = 0;
+        ctx.accounts.from_position.debt1_shares = 0;
+        ctx.accounts.from_position.bump = from_position_bump;
 
         emit_cpi!(UserPositionTransferredEvent {
             metadata: EventMetadata::new(current_owner_key, pair_key),

--- a/programs/omnipair/src/instructions/lending/transfer_user_position.rs
+++ b/programs/omnipair/src/instructions/lending/transfer_user_position.rs
@@ -1,0 +1,135 @@
+use anchor_lang::prelude::*;
+
+use crate::{
+    constants::*,
+    errors::ErrorCode,
+    events::{EventMetadata, UserPositionTransferredEvent, UserPositionUpdatedEvent},
+    state::{pair::Pair, user_position::UserPosition},
+    utils::account::get_size_with_discriminator,
+};
+
+#[event_cpi]
+#[derive(Accounts)]
+pub struct TransferUserPosition<'info> {
+    #[account(
+        seeds = [
+            PAIR_SEED_PREFIX,
+            pair.token0.as_ref(),
+            pair.token1.as_ref(),
+            pair.params_hash.as_ref()
+        ],
+        bump = pair.bump
+    )]
+    pub pair: Account<'info, Pair>,
+
+    #[account(
+        mut,
+        constraint = from_position.owner == current_owner.key() @ ErrorCode::InvalidPositionOwner,
+        constraint = from_position.pair == pair.key() @ ErrorCode::InvalidPair,
+        seeds = [
+            POSITION_SEED_PREFIX,
+            pair.key().as_ref(),
+            current_owner.key().as_ref()
+        ],
+        bump = from_position.bump
+    )]
+    pub from_position: Account<'info, UserPosition>,
+
+    #[account(
+        init_if_needed,
+        payer = current_owner,
+        space = get_size_with_discriminator::<UserPosition>(),
+        constraint = to_position.owner == Pubkey::default() || to_position.owner == new_owner.key() @ ErrorCode::InvalidPositionOwner,
+        constraint = to_position.pair == Pubkey::default() || to_position.pair == pair.key() @ ErrorCode::InvalidPair,
+        seeds = [
+            POSITION_SEED_PREFIX,
+            pair.key().as_ref(),
+            new_owner.key().as_ref()
+        ],
+        bump
+    )]
+    pub to_position: Account<'info, UserPosition>,
+
+    #[account(mut)]
+    pub current_owner: Signer<'info>,
+    pub new_owner: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+impl<'info> TransferUserPosition<'info> {
+    pub fn validate_transfer(&self) -> Result<()> {
+        require!(
+            self.from_position.is_initialized(),
+            ErrorCode::UserPositionNotInitialized
+        );
+        require_keys_neq!(
+            self.current_owner.key(),
+            self.new_owner.key(),
+            ErrorCode::InvalidPositionOwner
+        );
+        require!(
+            self.to_position.is_empty(),
+            ErrorCode::RecipientPositionNotEmpty
+        );
+
+        Ok(())
+    }
+
+    pub fn handle_transfer(ctx: Context<Self>) -> Result<()> {
+        let from_position_key = ctx.accounts.from_position.key();
+        let to_position_key = ctx.accounts.to_position.key();
+        let pair_key = ctx.accounts.pair.key();
+        let current_owner_key = ctx.accounts.current_owner.key();
+        let new_owner_key = ctx.accounts.new_owner.key();
+        let to_position_bump = ctx.bumps.to_position;
+
+        ctx.accounts.from_position.transfer_to(
+            &mut ctx.accounts.to_position,
+            new_owner_key,
+            pair_key,
+            to_position_bump,
+        )?;
+
+        emit_cpi!(UserPositionTransferredEvent {
+            metadata: EventMetadata::new(current_owner_key, pair_key),
+            from_position: from_position_key,
+            to_position: to_position_key,
+            from_owner: current_owner_key,
+            to_owner: new_owner_key,
+        });
+
+        emit_cpi!(UserPositionUpdatedEvent {
+            metadata: EventMetadata::new(current_owner_key, pair_key),
+            position: from_position_key,
+            collateral0: ctx.accounts.from_position.collateral0,
+            collateral1: ctx.accounts.from_position.collateral1,
+            debt0_shares: ctx.accounts.from_position.debt0_shares,
+            debt1_shares: ctx.accounts.from_position.debt1_shares,
+            collateral0_max_cf_bps: 0,
+            collateral1_max_cf_bps: 0,
+            collateral0_liquidation_cf_bps: 0,
+            collateral1_liquidation_cf_bps: 0,
+        });
+
+        emit_cpi!(UserPositionUpdatedEvent {
+            metadata: EventMetadata::new(new_owner_key, pair_key),
+            position: to_position_key,
+            collateral0: ctx.accounts.to_position.collateral0,
+            collateral1: ctx.accounts.to_position.collateral1,
+            debt0_shares: ctx.accounts.to_position.debt0_shares,
+            debt1_shares: ctx.accounts.to_position.debt1_shares,
+            collateral0_max_cf_bps: ctx
+                .accounts
+                .to_position
+                .get_max_cf_bps_for_debt_token(&ctx.accounts.pair, &ctx.accounts.pair.token1),
+            collateral1_max_cf_bps: ctx
+                .accounts
+                .to_position
+                .get_max_cf_bps_for_debt_token(&ctx.accounts.pair, &ctx.accounts.pair.token0),
+            collateral0_liquidation_cf_bps: ctx.accounts.to_position.collateral0_liquidation_cf_bps,
+            collateral1_liquidation_cf_bps: ctx.accounts.to_position.collateral1_liquidation_cf_bps,
+        });
+
+        Ok(())
+    }
+}

--- a/programs/omnipair/src/instructions/lending/transfer_user_position.rs
+++ b/programs/omnipair/src/instructions/lending/transfer_user_position.rs
@@ -58,24 +58,12 @@ pub struct TransferUserPosition<'info> {
 
 impl<'info> TransferUserPosition<'info> {
     pub fn validate_transfer(&self) -> Result<()> {
-        require!(
-            self.from_position.is_initialized(),
-            ErrorCode::UserPositionNotInitialized
-        );
-        require_keys_neq!(
+        validate_transfer_state(
+            &self.from_position,
+            &self.to_position,
             self.current_owner.key(),
             self.new_owner.key(),
-            ErrorCode::InvalidPositionOwner
-        );
-        require!(
-            self.to_position.collateral0 == 0
-                && self.to_position.collateral1 == 0
-                && self.to_position.debt0_shares == 0
-                && self.to_position.debt1_shares == 0,
-            ErrorCode::RecipientPositionNotEmpty
-        );
-
-        Ok(())
+        )
     }
 
     pub fn handle_transfer(ctx: Context<Self>) -> Result<()> {
@@ -84,30 +72,15 @@ impl<'info> TransferUserPosition<'info> {
         let pair_key = ctx.accounts.pair.key();
         let current_owner_key = ctx.accounts.current_owner.key();
         let new_owner_key = ctx.accounts.new_owner.key();
-        let from_position_bump = ctx.accounts.from_position.bump;
         let to_position_bump = ctx.bumps.to_position;
 
-        ctx.accounts.to_position.owner = new_owner_key;
-        ctx.accounts.to_position.pair = pair_key;
-        ctx.accounts.to_position.collateral0_liquidation_cf_bps =
-            ctx.accounts.from_position.collateral0_liquidation_cf_bps;
-        ctx.accounts.to_position.collateral1_liquidation_cf_bps =
-            ctx.accounts.from_position.collateral1_liquidation_cf_bps;
-        ctx.accounts.to_position.collateral0 = ctx.accounts.from_position.collateral0;
-        ctx.accounts.to_position.collateral1 = ctx.accounts.from_position.collateral1;
-        ctx.accounts.to_position.debt0_shares = ctx.accounts.from_position.debt0_shares;
-        ctx.accounts.to_position.debt1_shares = ctx.accounts.from_position.debt1_shares;
-        ctx.accounts.to_position.bump = to_position_bump;
-
-        ctx.accounts.from_position.owner = Pubkey::default();
-        ctx.accounts.from_position.pair = Pubkey::default();
-        ctx.accounts.from_position.collateral0_liquidation_cf_bps = 0;
-        ctx.accounts.from_position.collateral1_liquidation_cf_bps = 0;
-        ctx.accounts.from_position.collateral0 = 0;
-        ctx.accounts.from_position.collateral1 = 0;
-        ctx.accounts.from_position.debt0_shares = 0;
-        ctx.accounts.from_position.debt1_shares = 0;
-        ctx.accounts.from_position.bump = from_position_bump;
+        transfer_position_state(
+            &mut ctx.accounts.from_position,
+            &mut ctx.accounts.to_position,
+            pair_key,
+            new_owner_key,
+            to_position_bump,
+        );
 
         emit_cpi!(UserPositionTransferredEvent {
             metadata: EventMetadata::new(current_owner_key, pair_key),
@@ -150,5 +123,219 @@ impl<'info> TransferUserPosition<'info> {
         });
 
         Ok(())
+    }
+}
+
+fn validate_transfer_state(
+    from_position: &UserPosition,
+    to_position: &UserPosition,
+    current_owner: Pubkey,
+    new_owner: Pubkey,
+) -> Result<()> {
+    require!(
+        from_position.is_initialized(),
+        ErrorCode::UserPositionNotInitialized
+    );
+    require_keys_neq!(current_owner, new_owner, ErrorCode::InvalidPositionOwner);
+    require!(
+        to_position.collateral0 == 0
+            && to_position.collateral1 == 0
+            && to_position.debt0_shares == 0
+            && to_position.debt1_shares == 0,
+        ErrorCode::RecipientPositionNotEmpty
+    );
+
+    Ok(())
+}
+
+fn transfer_position_state(
+    from_position: &mut UserPosition,
+    to_position: &mut UserPosition,
+    pair_key: Pubkey,
+    new_owner_key: Pubkey,
+    to_position_bump: u8,
+) {
+    let from_position_bump = from_position.bump;
+
+    to_position.owner = new_owner_key;
+    to_position.pair = pair_key;
+    to_position.collateral0_liquidation_cf_bps = from_position.collateral0_liquidation_cf_bps;
+    to_position.collateral1_liquidation_cf_bps = from_position.collateral1_liquidation_cf_bps;
+    to_position.collateral0 = from_position.collateral0;
+    to_position.collateral1 = from_position.collateral1;
+    to_position.debt0_shares = from_position.debt0_shares;
+    to_position.debt1_shares = from_position.debt1_shares;
+    to_position.bump = to_position_bump;
+
+    from_position.owner = Pubkey::default();
+    from_position.pair = Pubkey::default();
+    from_position.collateral0_liquidation_cf_bps = 0;
+    from_position.collateral1_liquidation_cf_bps = 0;
+    from_position.collateral0 = 0;
+    from_position.collateral1 = 0;
+    from_position.debt0_shares = 0;
+    from_position.debt1_shares = 0;
+    from_position.bump = from_position_bump;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_position(owner: Pubkey, pair: Pubkey, bump: u8) -> UserPosition {
+        UserPosition {
+            owner,
+            pair,
+            collateral0_liquidation_cf_bps: 0,
+            collateral1_liquidation_cf_bps: 0,
+            collateral0: 0,
+            collateral1: 0,
+            debt0_shares: 0,
+            debt1_shares: 0,
+            bump,
+        }
+    }
+
+    fn populated_position(owner: Pubkey, pair: Pubkey, bump: u8) -> UserPosition {
+        UserPosition {
+            owner,
+            pair,
+            collateral0_liquidation_cf_bps: 7_500,
+            collateral1_liquidation_cf_bps: 6_900,
+            collateral0: 123_456,
+            collateral1: 654_321,
+            debt0_shares: 111_222_333,
+            debt1_shares: 444_555_666,
+            bump,
+        }
+    }
+
+    #[test]
+    fn transfer_validation_rejects_uninitialized_source() {
+        let current_owner = Pubkey::new_unique();
+        let new_owner = Pubkey::new_unique();
+        let pair = Pubkey::new_unique();
+        let from_position = empty_position(Pubkey::default(), Pubkey::default(), 1);
+        let to_position = empty_position(new_owner, pair, 2);
+
+        let err = validate_transfer_state(&from_position, &to_position, current_owner, new_owner)
+            .unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::UserPositionNotInitialized));
+    }
+
+    #[test]
+    fn transfer_validation_rejects_same_owner() {
+        let owner = Pubkey::new_unique();
+        let pair = Pubkey::new_unique();
+        let from_position = populated_position(owner, pair, 1);
+        let to_position = empty_position(owner, pair, 2);
+
+        let err = validate_transfer_state(&from_position, &to_position, owner, owner).unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::InvalidPositionOwner));
+    }
+
+    #[test]
+    fn transfer_validation_rejects_nonempty_recipient() {
+        let current_owner = Pubkey::new_unique();
+        let new_owner = Pubkey::new_unique();
+        let pair = Pubkey::new_unique();
+        let from_position = populated_position(current_owner, pair, 1);
+        let mut to_position = empty_position(new_owner, pair, 2);
+        to_position.debt1_shares = 1;
+
+        let err = validate_transfer_state(&from_position, &to_position, current_owner, new_owner)
+            .unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::RecipientPositionNotEmpty));
+    }
+
+    #[test]
+    fn transfer_state_moves_position_and_clears_source_without_changing_totals() {
+        let current_owner = Pubkey::new_unique();
+        let new_owner = Pubkey::new_unique();
+        let pair = Pubkey::new_unique();
+        let mut from_position = populated_position(current_owner, pair, 9);
+        let mut to_position = empty_position(new_owner, pair, 3);
+        let total_collateral0_before = from_position.collateral0 + to_position.collateral0;
+        let total_collateral1_before = from_position.collateral1 + to_position.collateral1;
+        let total_debt0_shares_before = from_position.debt0_shares + to_position.debt0_shares;
+        let total_debt1_shares_before = from_position.debt1_shares + to_position.debt1_shares;
+
+        validate_transfer_state(&from_position, &to_position, current_owner, new_owner).unwrap();
+        transfer_position_state(&mut from_position, &mut to_position, pair, new_owner, 3);
+
+        assert_eq!(to_position.owner, new_owner);
+        assert_eq!(to_position.pair, pair);
+        assert_eq!(to_position.collateral0_liquidation_cf_bps, 7_500);
+        assert_eq!(to_position.collateral1_liquidation_cf_bps, 6_900);
+        assert_eq!(to_position.collateral0, 123_456);
+        assert_eq!(to_position.collateral1, 654_321);
+        assert_eq!(to_position.debt0_shares, 111_222_333);
+        assert_eq!(to_position.debt1_shares, 444_555_666);
+        assert_eq!(to_position.bump, 3);
+
+        assert_eq!(from_position.owner, Pubkey::default());
+        assert_eq!(from_position.pair, Pubkey::default());
+        assert_eq!(from_position.collateral0_liquidation_cf_bps, 0);
+        assert_eq!(from_position.collateral1_liquidation_cf_bps, 0);
+        assert_eq!(from_position.collateral0, 0);
+        assert_eq!(from_position.collateral1, 0);
+        assert_eq!(from_position.debt0_shares, 0);
+        assert_eq!(from_position.debt1_shares, 0);
+        assert_eq!(from_position.bump, 9);
+
+        assert_eq!(
+            from_position.collateral0 + to_position.collateral0,
+            total_collateral0_before
+        );
+        assert_eq!(
+            from_position.collateral1 + to_position.collateral1,
+            total_collateral1_before
+        );
+        assert_eq!(
+            from_position.debt0_shares + to_position.debt0_shares,
+            total_debt0_shares_before
+        );
+        assert_eq!(
+            from_position.debt1_shares + to_position.debt1_shares,
+            total_debt1_shares_before
+        );
+    }
+
+    #[test]
+    fn transfer_state_can_reuse_a_cleared_source_as_destination() {
+        let owner_a = Pubkey::new_unique();
+        let owner_b = Pubkey::new_unique();
+        let pair = Pubkey::new_unique();
+        let mut owner_a_position = populated_position(owner_a, pair, 8);
+        let mut owner_b_position = empty_position(owner_b, pair, 5);
+
+        transfer_position_state(
+            &mut owner_a_position,
+            &mut owner_b_position,
+            pair,
+            owner_b,
+            5,
+        );
+        validate_transfer_state(&owner_b_position, &owner_a_position, owner_b, owner_a).unwrap();
+        transfer_position_state(
+            &mut owner_b_position,
+            &mut owner_a_position,
+            pair,
+            owner_a,
+            8,
+        );
+
+        assert_eq!(owner_a_position.owner, owner_a);
+        assert_eq!(owner_a_position.pair, pair);
+        assert_eq!(owner_a_position.collateral0, 123_456);
+        assert_eq!(owner_a_position.collateral1, 654_321);
+        assert_eq!(owner_a_position.debt0_shares, 111_222_333);
+        assert_eq!(owner_a_position.debt1_shares, 444_555_666);
+        assert_eq!(owner_a_position.bump, 8);
+        assert!(!owner_b_position.is_initialized());
+        assert_eq!(owner_b_position.bump, 5);
     }
 }

--- a/programs/omnipair/src/instructions/liquidity/add_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/add_liquidity.rs
@@ -1,22 +1,28 @@
-use anchor_lang::prelude::*;
-use crate::errors::ErrorCode;
 use crate::constants::*;
-use crate::utils::token::{transfer_from_user_to_vault, token_mint_to};
-use crate::utils::math::ceil_div;
-use crate::utils::liquidity_delta_circuit_breaker::{require_top_level_liquidity_delta_ix, LiquidityDeltaInstruction};
+use crate::errors::ErrorCode;
+use crate::events::{EventMetadata, MintEvent, UserLiquidityPositionUpdatedEvent};
 use crate::generate_gamm_pair_seeds;
-use crate::liquidity::common::{AdjustLiquidity, AddLiquidityArgs};
-use crate::events::{MintEvent, UserLiquidityPositionUpdatedEvent, EventMetadata};
+use crate::liquidity::common::{AddLiquidityArgs, AdjustLiquidity};
+use crate::utils::liquidity_delta_circuit_breaker::{
+    require_top_level_liquidity_delta_ix, LiquidityDeltaInstruction,
+};
+use crate::utils::math::ceil_div;
+use crate::utils::token::{
+    amount_with_transfer_fee, token_mint_to, token_program_for_mint, transfer_from_user_to_vault,
+};
+use anchor_lang::prelude::*;
 
 impl<'info> AdjustLiquidity<'info> {
     fn validate_add(&self, args: &AddLiquidityArgs) -> Result<()> {
-        let AdjustLiquidity { 
+        let AdjustLiquidity {
             user_token0_account,
             user_token1_account,
+            token0_mint,
+            token1_mint,
             futarchy_authority,
             pair,
             instructions_sysvar,
-            .. 
+            ..
         } = self;
 
         require_top_level_liquidity_delta_ix(
@@ -31,16 +37,28 @@ impl<'info> AdjustLiquidity<'info> {
             ErrorCode::ReduceOnlyMode
         );
 
-        let AddLiquidityArgs { 
-            amount0_in, 
-            amount1_in, 
-            .. 
+        let AddLiquidityArgs {
+            amount0_in,
+            amount1_in,
+            ..
         } = args;
-        
+
         require!(*amount0_in > 0 && *amount1_in > 0, ErrorCode::AmountZero);
-        require_gte!(user_token0_account.amount, *amount0_in, ErrorCode::InsufficientAmount0In);
-        require_gte!(user_token1_account.amount, *amount1_in, ErrorCode::InsufficientAmount1In);
-        
+        let amount0_transfer_in =
+            amount_with_transfer_fee(&token0_mint.to_account_info(), *amount0_in)?;
+        let amount1_transfer_in =
+            amount_with_transfer_fee(&token1_mint.to_account_info(), *amount1_in)?;
+        require_gte!(
+            user_token0_account.amount,
+            amount0_transfer_in,
+            ErrorCode::InsufficientAmount0In
+        );
+        require_gte!(
+            user_token1_account.amount,
+            amount1_transfer_in,
+            ErrorCode::InsufficientAmount1In
+        );
+
         Ok(())
     }
 
@@ -70,15 +88,22 @@ impl<'info> AdjustLiquidity<'info> {
         // Calculate liquidity based on input amounts
         let total_supply = pair.total_supply; // total supply is set to MIN_LIQUIDITY in initialize
         let liquidity: u64 = {
-                let liquidity0 = (args.amount0_in as u128)
-                    .checked_mul(total_supply as u128).ok_or(ErrorCode::LiquidityMathOverflow)?
-                    .checked_div(pair.reserve0 as u128).ok_or(ErrorCode::LiquidityMathOverflow)?;
-                let liquidity1 = (args.amount1_in as u128)
-                    .checked_mul(total_supply as u128).ok_or(ErrorCode::LiquidityMathOverflow)?
-                    .checked_div(pair.reserve1 as u128).ok_or(ErrorCode::LiquidityMathOverflow)?;
-                liquidity0.min(liquidity1).try_into().map_err(|_| ErrorCode::LiquidityConversionOverflow)?
-            };
-        
+            let liquidity0 = (args.amount0_in as u128)
+                .checked_mul(total_supply as u128)
+                .ok_or(ErrorCode::LiquidityMathOverflow)?
+                .checked_div(pair.reserve0 as u128)
+                .ok_or(ErrorCode::LiquidityMathOverflow)?;
+            let liquidity1 = (args.amount1_in as u128)
+                .checked_mul(total_supply as u128)
+                .ok_or(ErrorCode::LiquidityMathOverflow)?
+                .checked_div(pair.reserve1 as u128)
+                .ok_or(ErrorCode::LiquidityMathOverflow)?;
+            liquidity0
+                .min(liquidity1)
+                .try_into()
+                .map_err(|_| ErrorCode::LiquidityConversionOverflow)?
+        };
+
         // Check if liquidity meets minimum (slippage protection)
         require!(
             liquidity >= args.min_liquidity_out,
@@ -88,18 +113,29 @@ impl<'info> AdjustLiquidity<'info> {
         // Calculate exact amounts to transfer based on liquidity minted
         // amount_used = ceil(liquidity * reserve / total_supply) - round up to favor protocol
         let amount0_used: u64 = ceil_div(
-            (liquidity as u128).checked_mul(pair.reserve0 as u128).ok_or(ErrorCode::LiquidityMathOverflow)?,
-            total_supply as u128
-        ).ok_or(ErrorCode::LiquidityMathOverflow)?
-            .try_into()
-            .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
-        
+            (liquidity as u128)
+                .checked_mul(pair.reserve0 as u128)
+                .ok_or(ErrorCode::LiquidityMathOverflow)?,
+            total_supply as u128,
+        )
+        .ok_or(ErrorCode::LiquidityMathOverflow)?
+        .try_into()
+        .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
+
         let amount1_used: u64 = ceil_div(
-            (liquidity as u128).checked_mul(pair.reserve1 as u128).ok_or(ErrorCode::LiquidityMathOverflow)?,
-            total_supply as u128
-        ).ok_or(ErrorCode::LiquidityMathOverflow)?
-            .try_into()
-            .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
+            (liquidity as u128)
+                .checked_mul(pair.reserve1 as u128)
+                .ok_or(ErrorCode::LiquidityMathOverflow)?,
+            total_supply as u128,
+        )
+        .ok_or(ErrorCode::LiquidityMathOverflow)?
+        .try_into()
+        .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
+
+        let amount0_transfer_in =
+            amount_with_transfer_fee(&token0_mint.to_account_info(), amount0_used)?;
+        let amount1_transfer_in =
+            amount_with_transfer_fee(&token1_mint.to_account_info(), amount1_used)?;
 
         // Transfer only the exact amounts needed
         transfer_from_user_to_vault(
@@ -107,11 +143,12 @@ impl<'info> AdjustLiquidity<'info> {
             user_token0_account.to_account_info(),
             reserve0_vault.to_account_info(),
             token0_mint.to_account_info(),
-            match token0_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
-            amount0_used,
+            token_program_for_mint(
+                &token0_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
+            amount0_transfer_in,
             token0_mint.decimals,
         )?;
         transfer_from_user_to_vault(
@@ -119,14 +156,15 @@ impl<'info> AdjustLiquidity<'info> {
             user_token1_account.to_account_info(),
             reserve1_vault.to_account_info(),
             token1_mint.to_account_info(),
-            match token1_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
-            amount1_used,
+            token_program_for_mint(
+                &token1_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
+            amount1_transfer_in,
             token1_mint.decimals,
         )?;
-        
+
         // Mint LP tokens to user
         token_mint_to(
             pair.to_account_info(),
@@ -136,31 +174,36 @@ impl<'info> AdjustLiquidity<'info> {
             liquidity as u64,
             &[&generate_gamm_pair_seeds!(pair)[..]],
         )?;
-        
+
         // liqudity additions equally increase both virtual and cash reserves
         // r_virtual + (amount) = r_cash + (amount) + r_debt
         // Update reserves
-        pair.reserve0 = pair.reserve0
+        pair.reserve0 = pair
+            .reserve0
             .checked_add(amount0_used)
             .ok_or(ErrorCode::ReserveOverflow)?;
-        pair.reserve1 = pair.reserve1
+        pair.reserve1 = pair
+            .reserve1
             .checked_add(amount1_used)
             .ok_or(ErrorCode::ReserveOverflow)?;
-        pair.total_supply = pair.total_supply
+        pair.total_supply = pair
+            .total_supply
             .checked_add(liquidity)
             .ok_or(ErrorCode::SupplyOverflow)?;
 
         // Update cash reserves
-        pair.cash_reserve0 = pair.cash_reserve0
+        pair.cash_reserve0 = pair
+            .cash_reserve0
             .checked_add(amount0_used)
             .ok_or(ErrorCode::ReserveOverflow)?;
-        pair.cash_reserve1 = pair.cash_reserve1
+        pair.cash_reserve1 = pair
+            .cash_reserve1
             .checked_add(amount1_used)
             .ok_or(ErrorCode::ReserveOverflow)?;
-        
+
         user_lp_token_account.reload()?;
         let user_lp_balance = user_lp_token_account.amount;
-        
+
         let user_token0_amount = (user_lp_balance as u128)
             .checked_mul(pair.reserve0 as u128)
             .ok_or(ErrorCode::LiquidityMathOverflow)?
@@ -175,7 +218,7 @@ impl<'info> AdjustLiquidity<'info> {
             .ok_or(ErrorCode::LiquidityMathOverflow)?
             .try_into()
             .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
-        
+
         // Emit event
         emit_cpi!(MintEvent {
             metadata: EventMetadata::new(user.key(), pair.key()),
@@ -195,7 +238,7 @@ impl<'info> AdjustLiquidity<'info> {
             token1_mint: pair.token1,
             lp_mint: lp_mint.key(),
         });
-        
+
         Ok(())
     }
 }

--- a/programs/omnipair/src/instructions/liquidity/common.rs
+++ b/programs/omnipair/src/instructions/liquidity/common.rs
@@ -1,18 +1,12 @@
-use anchor_lang::{
-    prelude::*,
-    solana_program::sysvar,
-};
-use anchor_spl::{
-    token::{Token, TokenAccount, Mint},
-    token_interface::{Token2022},
-    associated_token::AssociatedToken,
-};
 use crate::{
-    state::pair::Pair,
-    state::rate_model::RateModel,
-    state::futarchy_authority::FutarchyAuthority,
-    constants::*,
-    errors::ErrorCode,
+    constants::*, errors::ErrorCode, state::futarchy_authority::FutarchyAuthority,
+    state::pair::Pair, state::rate_model::RateModel,
+};
+use anchor_lang::{prelude::*, solana_program::sysvar};
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{Mint as SplMint, Token, TokenAccount as SplTokenAccount},
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -28,7 +22,7 @@ pub struct AdjustLiquidity<'info> {
     #[account(
         mut,
         seeds = [
-            PAIR_SEED_PREFIX, 
+            PAIR_SEED_PREFIX,
             pair.token0.as_ref(),
             pair.token1.as_ref(),
             pair.params_hash.as_ref()
@@ -48,7 +42,7 @@ pub struct AdjustLiquidity<'info> {
         bump = futarchy_authority.bump
     )]
     pub futarchy_authority: Account<'info, FutarchyAuthority>,
-    
+
     #[account(
         mut,
         seeds = [
@@ -58,8 +52,8 @@ pub struct AdjustLiquidity<'info> {
         ],
         bump = pair.vault_bumps.reserve0
     )]
-    pub reserve0_vault: Box<Account<'info, TokenAccount>>,
-    
+    pub reserve0_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
     #[account(
         mut,
         seeds = [
@@ -69,38 +63,38 @@ pub struct AdjustLiquidity<'info> {
         ],
         bump = pair.vault_bumps.reserve1
     )]
-    pub reserve1_vault: Box<Account<'info, TokenAccount>>,
-    
+    pub reserve1_vault: Box<InterfaceAccount<'info, TokenAccount>>,
+
     #[account(
         mut,
-        token::mint = pair.token0,
-        token::authority = user,
+        constraint = user_token0_account.mint == pair.token0 @ ErrorCode::InvalidTokenAccount,
+        constraint = user_token0_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_token0_account: Box<Account<'info, TokenAccount>>,
-    
+    pub user_token0_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
     #[account(
         mut,
-        token::mint = pair.token1,
-        token::authority = user,
+        constraint = user_token1_account.mint == pair.token1 @ ErrorCode::InvalidTokenAccount,
+        constraint = user_token1_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_token1_account: Box<Account<'info, TokenAccount>>,
+    pub user_token1_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         address = pair.token0 @ ErrorCode::InvalidMint
     )]
-    pub token0_mint: Box<Account<'info, Mint>>,
+    pub token0_mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         address = pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub token1_mint: Box<Account<'info, Mint>>,
-    
+    pub token1_mint: Box<InterfaceAccount<'info, Mint>>,
+
     #[account(
         mut,
         address = pair.lp_mint @ ErrorCode::InvalidMint,
     )]
-    pub lp_mint: Box<Account<'info, Mint>>,
-    
+    pub lp_mint: Box<Account<'info, SplMint>>,
+
     #[account(
         init_if_needed,
         associated_token::mint = lp_mint,
@@ -108,8 +102,8 @@ pub struct AdjustLiquidity<'info> {
         payer = user,
         token::token_program = token_program,
     )]
-    pub user_lp_token_account: Box<Account<'info, TokenAccount>>,
-    
+    pub user_lp_token_account: Box<Account<'info, SplTokenAccount>>,
+
     #[account(mut)]
     pub user: Signer<'info>,
     pub token_program: Program<'info, Token>,

--- a/programs/omnipair/src/instructions/liquidity/initialize.rs
+++ b/programs/omnipair/src/instructions/liquidity/initialize.rs
@@ -1,46 +1,42 @@
-use anchor_lang::{
-    prelude::*, 
-    solana_program::{
-        program::invoke, 
-        system_instruction,
-        hash::hash,
-    }
+use crate::constants::*;
+use crate::errors::ErrorCode;
+use crate::events::{
+    EventMetadata, MintEvent, PairCreatedEvent, UserLiquidityPositionUpdatedEvent,
 };
-use anchor_spl::{
-    token::spl_token,
-    token::{Token, TokenAccount, Mint},
-    token_interface::{Token2022},
-    associated_token::{AssociatedToken, create_idempotent},
+use crate::generate_gamm_pair_seeds;
+use crate::state::{
+    futarchy_authority::FutarchyAuthority,
+    pair::{LastPriceEMA, Pair, VaultBumps},
+    rate_model::RateModel,
 };
-use anchor_spl::metadata::{
-    create_metadata_accounts_v3,
-    mpl_token_metadata::types::DataV2,
-    mpl_token_metadata::ID as MPL_TOKEN_METADATA_PROGRAM_ID,
-    CreateMetadataAccountsV3, Metadata,
+use crate::utils::account::get_size_with_discriminator;
+use crate::utils::math::SqrtU128;
+use crate::utils::token::{
+    amount_with_transfer_fee, create_token_account, is_supported_mint, token_mint_to,
+    token_program_for_mint, transfer_from_user_to_vault,
 };
 use anchor_lang::solana_program::program_pack::Pack;
-use crate::state::{
-    pair::{Pair, VaultBumps, LastPriceEMA},
-    rate_model::RateModel,
-    futarchy_authority::FutarchyAuthority,
+use anchor_lang::{
+    prelude::*,
+    solana_program::{hash::hash, program::invoke, system_instruction},
 };
-use crate::errors::ErrorCode;
-use crate::constants::*;
-use crate::utils::account::get_size_with_discriminator;
-use crate::utils::token::{
-    transfer_from_user_to_vault,
-    token_mint_to,  
+use anchor_spl::metadata::{
+    create_metadata_accounts_v3, mpl_token_metadata::types::DataV2,
+    mpl_token_metadata::ID as MPL_TOKEN_METADATA_PROGRAM_ID, CreateMetadataAccountsV3, Metadata,
 };
-use crate::utils::math::SqrtU128;
-use crate::events::{PairCreatedEvent, MintEvent, UserLiquidityPositionUpdatedEvent, EventMetadata};
-use crate::generate_gamm_pair_seeds;
+use anchor_spl::{
+    associated_token::{create_idempotent, AssociatedToken},
+    token::spl_token,
+    token::{Token, TokenAccount as SplTokenAccount},
+    token_interface::{Mint, Token2022, TokenAccount},
+};
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct InitializeAndBootstrapArgs {
     pub swap_fee_bps: u16,
     pub half_life: u64,
     pub fixed_cf_bps: Option<u16>,
-    
+
     // Interest rate controller parameters (all optional, use defaults if None)
     pub target_util_start_bps: Option<u64>, // utilization lower bound (defaults to 30%)
     pub target_util_end_bps: Option<u64>,   // utilization upper bound (defaults to 50%)
@@ -48,7 +44,7 @@ pub struct InitializeAndBootstrapArgs {
     pub min_rate_bps: Option<u64>,          // rate floor (defaults to 1%)
     pub max_rate_bps: Option<u64>,          // rate ceiling (defaults to 500%, 0 = no cap)
     pub initial_rate_bps: Option<u64>,      // starting rate (defaults to 2%)
-    
+
     pub params_hash: [u8; 32],
     pub version: u8,
 
@@ -68,16 +64,16 @@ pub struct InitializeAndBootstrap<'info> {
     #[account(mut)]
     pub deployer: Signer<'info>,
 
-    pub token0_mint: Box<Account<'info, Mint>>,
-    pub token1_mint: Box<Account<'info, Mint>>,
-    
+    pub token0_mint: Box<InterfaceAccount<'info, Mint>>,
+    pub token1_mint: Box<InterfaceAccount<'info, Mint>>,
+
     #[account(
         init,
         payer = deployer,
         space = get_size_with_discriminator::<Pair>(),
         seeds = [
-            PAIR_SEED_PREFIX, 
-            token0_mint.key().as_ref(), 
+            PAIR_SEED_PREFIX,
+            token0_mint.key().as_ref(),
             token1_mint.key().as_ref(),
             args.params_hash.as_ref(),
         ],
@@ -119,74 +115,66 @@ pub struct InitializeAndBootstrap<'info> {
     pub deployer_lp_token_account: UncheckedAccount<'info>,
 
     #[account(
-        init,
+        mut,
         seeds = [
             RESERVE_VAULT_SEED_PREFIX,
             pair.key().as_ref(),
             token0_mint.key().as_ref(),
         ],
-        payer = deployer,
-        token::mint = token0_mint,
-        token::authority = pair,
         bump
     )]
-    pub reserve0_vault: Box<Account<'info, TokenAccount>>,
-    
-    #[account(
-        init,
-        seeds = [
-            RESERVE_VAULT_SEED_PREFIX,
-            pair.key().as_ref(),
-            token1_mint.key().as_ref(),
-        ],
-        payer = deployer,
-        token::mint = token1_mint,
-        token::authority = pair,
-        bump
-    )]
-    pub reserve1_vault: Box<Account<'info, TokenAccount>>,
+    /// CHECK: Created as a token account for token0_mint in the handler.
+    pub reserve0_vault: UncheckedAccount<'info>,
 
     #[account(
-        init,
+        mut,
+        seeds = [
+            RESERVE_VAULT_SEED_PREFIX,
+            pair.key().as_ref(),
+            token1_mint.key().as_ref(),
+        ],
+        bump
+    )]
+    /// CHECK: Created as a token account for token1_mint in the handler.
+    pub reserve1_vault: UncheckedAccount<'info>,
+
+    #[account(
+        mut,
         seeds = [
             COLLATERAL_VAULT_SEED_PREFIX,
             pair.key().as_ref(),
             token0_mint.key().as_ref(),
         ],
-        payer = deployer,
-        token::mint = token0_mint,
-        token::authority = pair,
         bump
     )]
-    pub collateral0_vault: Box<Account<'info, TokenAccount>>,
-    
+    /// CHECK: Created as a token account for token0_mint in the handler.
+    pub collateral0_vault: UncheckedAccount<'info>,
+
     #[account(
-        init,
+        mut,
         seeds = [
             COLLATERAL_VAULT_SEED_PREFIX,
             pair.key().as_ref(),
             token1_mint.key().as_ref(),
         ],
-        payer = deployer,
-        token::mint = token1_mint,
-        token::authority = pair,
         bump
     )]
-    pub collateral1_vault: Box<Account<'info, TokenAccount>>,
-    
+    /// CHECK: Created as a token account for token1_mint in the handler.
+    pub collateral1_vault: UncheckedAccount<'info>,
+
     #[account(
         mut,
-        token::mint = token0_mint,
-        token::authority = deployer,
+        constraint = deployer_token0_account.mint == token0_mint.key() @ ErrorCode::InvalidTokenAccount,
+        constraint = deployer_token0_account.owner == deployer.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub deployer_token0_account: Box<Account<'info, TokenAccount>>,
-    
+    pub deployer_token0_account: Box<InterfaceAccount<'info, TokenAccount>>,
+
     #[account(
         mut,
-        token::mint = token1_mint,
-        token::authority = deployer,
+        constraint = deployer_token1_account.mint == token1_mint.key() @ ErrorCode::InvalidTokenAccount,
+        constraint = deployer_token1_account.owner == deployer.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub deployer_token1_account: Box<Account<'info, TokenAccount>>,
+    pub deployer_token1_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// CHECK: Validated against futarchy_authority.recipients.team_treasury
     #[account(
@@ -200,7 +188,7 @@ pub struct InitializeAndBootstrap<'info> {
         constraint = team_treasury_wsol_account.owner == futarchy_authority.recipients.team_treasury @ ErrorCode::InvalidRecipient,
         constraint = *team_treasury_wsol_account.to_account_info().owner == token_program.key() @ ErrorCode::InvalidTokenProgram,
     )]
-    pub team_treasury_wsol_account: Box<Account<'info, TokenAccount>>,
+    pub team_treasury_wsol_account: Box<Account<'info, SplTokenAccount>>,
 
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,
@@ -212,9 +200,9 @@ pub struct InitializeAndBootstrap<'info> {
 
 impl<'info> InitializeAndBootstrap<'info> {
     pub fn validate(&self, args: &InitializeAndBootstrapArgs) -> Result<()> {
-        let InitializeAndBootstrapArgs { 
+        let InitializeAndBootstrapArgs {
             version,
-            swap_fee_bps, 
+            swap_fee_bps,
             half_life,
             fixed_cf_bps,
             target_util_start_bps,
@@ -234,11 +222,27 @@ impl<'info> InitializeAndBootstrap<'info> {
 
         // tokens canonical order check (token0 > token1)
         // this prevents the same token pair from having two valid addresses (0,1) and (1,0)
-        require_gt!(self.token1_mint.key(), self.token0_mint.key(), ErrorCode::InvalidTokenOrder);
+        require_gt!(
+            self.token1_mint.key(),
+            self.token0_mint.key(),
+            ErrorCode::InvalidTokenOrder
+        );
+        require!(
+            is_supported_mint(&self.token0_mint)?,
+            ErrorCode::InvalidMint
+        );
+        require!(
+            is_supported_mint(&self.token1_mint)?,
+            ErrorCode::InvalidMint
+        );
 
         // validate pool parameters
         require_eq!(*version, VERSION, ErrorCode::InvalidVersion);
-        require_gte!(BPS_DENOMINATOR / 2, *swap_fee_bps, ErrorCode::InvalidSwapFeeBps); // 0 <= swap_fee_bps <= 50%
+        require_gte!(
+            BPS_DENOMINATOR / 2,
+            *swap_fee_bps,
+            ErrorCode::InvalidSwapFeeBps
+        ); // 0 <= swap_fee_bps <= 50%
         require_gte!(*half_life, MIN_HALF_LIFE_MS, ErrorCode::InvalidHalfLife); // half_life >= 1 minute
         require_gte!(MAX_HALF_LIFE_MS, *half_life, ErrorCode::InvalidHalfLife); // half_life <= 12 hours
 
@@ -251,7 +255,10 @@ impl<'info> InitializeAndBootstrap<'info> {
         // validate utilization bounds if provided (both must be provided together, or neither)
         let util_start = target_util_start_bps.unwrap_or(TARGET_UTIL_START_BPS);
         let util_end = target_util_end_bps.unwrap_or(TARGET_UTIL_END_BPS);
-        require!(RateModel::validate_util_bounds(util_start, util_end), ErrorCode::InvalidUtilBounds);
+        require!(
+            RateModel::validate_util_bounds(util_start, util_end),
+            ErrorCode::InvalidUtilBounds
+        );
 
         // Validate interest rate controller parameters
         let rate_hl = rate_half_life_ms.unwrap_or(DEFAULT_RATE_HALF_LIFE_MS);
@@ -264,7 +271,7 @@ impl<'info> InitializeAndBootstrap<'info> {
         );
 
         // Verify params_hash matches the computed hash
-        // SHA256(VERSION || swap_fee_bps || half_life || fixed_cf_bps || target_util_start_bps || target_util_end_bps 
+        // SHA256(VERSION || swap_fee_bps || half_life || fixed_cf_bps || target_util_start_bps || target_util_end_bps
         //        || rate_half_life_ms || min_rate_bps || max_rate_bps)
         let mut hash_data = Vec::new();
         hash_data.extend_from_slice(&VERSION.to_le_bytes());
@@ -277,29 +284,47 @@ impl<'info> InitializeAndBootstrap<'info> {
         hash_data.extend_from_slice(&min_rate_bps.unwrap_or(0).to_le_bytes());
         hash_data.extend_from_slice(&max_rate_bps.unwrap_or(0).to_le_bytes());
         let computed_hash = hash(&hash_data).to_bytes();
-        let hashes_match = computed_hash.iter().zip(params_hash.iter()).all(|(a, b)| a == b);
+        let hashes_match = computed_hash
+            .iter()
+            .zip(params_hash.iter())
+            .all(|(a, b)| a == b);
         require!(hashes_match, ErrorCode::InvalidParamsHash);
 
         // validate bootstrap parameters
         require!(*amount0_in > 0 && *amount1_in > 0, ErrorCode::AmountZero);
-        require_gte!(self.deployer_token0_account.amount, *amount0_in, ErrorCode::InsufficientAmount0In);
-        require_gte!(self.deployer_token1_account.amount, *amount1_in, ErrorCode::InsufficientAmount1In);
+        let amount0_transfer_in =
+            amount_with_transfer_fee(&self.token0_mint.to_account_info(), *amount0_in)?;
+        let amount1_transfer_in =
+            amount_with_transfer_fee(&self.token1_mint.to_account_info(), *amount1_in)?;
+        require_gte!(
+            self.deployer_token0_account.amount,
+            amount0_transfer_in,
+            ErrorCode::InsufficientAmount0In
+        );
+        require_gte!(
+            self.deployer_token1_account.amount,
+            amount1_transfer_in,
+            ErrorCode::InsufficientAmount1In
+        );
 
         #[cfg(feature = "production")]
         {
             let lp_mint_key: String = self.lp_mint.key().to_string();
-            let start_idx = lp_mint_key.len().checked_sub(4).ok_or(ErrorCode::InvalidLpMintKey)?;
+            let start_idx = lp_mint_key
+                .len()
+                .checked_sub(4)
+                .ok_or(ErrorCode::InvalidLpMintKey)?;
             let last_4_chars = &lp_mint_key[start_idx..];
             require_eq!("omLP", last_4_chars, ErrorCode::InvalidLpMintKey);
         }
-    
+
         require!(lp_name.len() <= 32, ErrorCode::InvalidLpName);
         require!(lp_name.is_ascii(), ErrorCode::InvalidLpName);
         require!(lp_symbol.len() <= 10, ErrorCode::InvalidLpSymbol);
         require!(lp_symbol.is_ascii(), ErrorCode::InvalidLpSymbol);
         require!(lp_uri.len() <= 200, ErrorCode::InvalidLpUri);
         require!(lp_uri.starts_with("http"), ErrorCode::InvalidLpUri);
-        
+
         Ok(())
     }
 
@@ -307,10 +332,10 @@ impl<'info> InitializeAndBootstrap<'info> {
         let current_slot = Clock::get()?.slot;
         let pair_key = ctx.accounts.pair.key();
         let pair = &mut ctx.accounts.pair;
-        
-        let InitializeAndBootstrapArgs { 
-            swap_fee_bps, 
-            half_life, 
+
+        let InitializeAndBootstrapArgs {
+            swap_fee_bps,
+            half_life,
             fixed_cf_bps,
             target_util_start_bps,
             target_util_end_bps,
@@ -352,17 +377,10 @@ impl<'info> InitializeAndBootstrap<'info> {
                 ctx.accounts.team_treasury_wsol_account.to_account_info(),
             ],
         )?;
-        
-        let (
-            token0, 
-            token1, 
-            token0_decimals,
-            token1_decimals,
-            rate_model_key,
-            lp_mint_key
-        ) = (
-            ctx.accounts.token0_mint.key(), 
-            ctx.accounts.token1_mint.key(), 
+
+        let (token0, token1, token0_decimals, token1_decimals, rate_model_key, lp_mint_key) = (
+            ctx.accounts.token0_mint.key(),
+            ctx.accounts.token1_mint.key(),
             ctx.accounts.token0_mint.decimals,
             ctx.accounts.token1_mint.decimals,
             ctx.accounts.rate_model.key(),
@@ -376,14 +394,9 @@ impl<'info> InitializeAndBootstrap<'info> {
         let min_rate = min_rate_bps.unwrap_or(DEFAULT_MIN_RATE_BPS);
         let max_rate = max_rate_bps.unwrap_or(DEFAULT_MAX_RATE_BPS);
         let init_rate = initial_rate_bps.unwrap_or(DEFAULT_INITIAL_RATE_BPS);
-        
+
         ctx.accounts.rate_model.set_inner(RateModel::new(
-            util_start,
-            util_end,
-            rate_hl,
-            min_rate,
-            max_rate,
-            init_rate,
+            util_start, util_end, rate_hl, min_rate, max_rate, init_rate,
         ));
 
         // Initialize pair (before LP mint is initialized, but we store the key)
@@ -412,17 +425,98 @@ impl<'info> InitializeAndBootstrap<'info> {
             ctx.accounts.rate_model.initial_rate, // Use rate model's configured initial rate (NAD-scaled)
         ));
 
+        let token0_program = token_program_for_mint(
+            &ctx.accounts.token0_mint.to_account_info(),
+            &ctx.accounts.token_program.to_account_info(),
+            &ctx.accounts.token_2022_program.to_account_info(),
+        )?;
+        let token1_program = token_program_for_mint(
+            &ctx.accounts.token1_mint.to_account_info(),
+            &ctx.accounts.token_program.to_account_info(),
+            &ctx.accounts.token_2022_program.to_account_info(),
+        )?;
+
+        let reserve0_bump = [ctx.bumps.reserve0_vault];
+        let reserve0_seeds = &[
+            RESERVE_VAULT_SEED_PREFIX,
+            pair_key.as_ref(),
+            token0.as_ref(),
+            reserve0_bump.as_ref(),
+        ];
+        create_token_account(
+            &pair.to_account_info(),
+            &ctx.accounts.deployer.to_account_info(),
+            &ctx.accounts.reserve0_vault.to_account_info(),
+            &ctx.accounts.token0_mint.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &token0_program,
+            reserve0_seeds,
+        )?;
+
+        let reserve1_bump = [ctx.bumps.reserve1_vault];
+        let reserve1_seeds = &[
+            RESERVE_VAULT_SEED_PREFIX,
+            pair_key.as_ref(),
+            token1.as_ref(),
+            reserve1_bump.as_ref(),
+        ];
+        create_token_account(
+            &pair.to_account_info(),
+            &ctx.accounts.deployer.to_account_info(),
+            &ctx.accounts.reserve1_vault.to_account_info(),
+            &ctx.accounts.token1_mint.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &token1_program,
+            reserve1_seeds,
+        )?;
+
+        let collateral0_bump = [ctx.bumps.collateral0_vault];
+        let collateral0_seeds = &[
+            COLLATERAL_VAULT_SEED_PREFIX,
+            pair_key.as_ref(),
+            token0.as_ref(),
+            collateral0_bump.as_ref(),
+        ];
+        create_token_account(
+            &pair.to_account_info(),
+            &ctx.accounts.deployer.to_account_info(),
+            &ctx.accounts.collateral0_vault.to_account_info(),
+            &ctx.accounts.token0_mint.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &token0_program,
+            collateral0_seeds,
+        )?;
+
+        let collateral1_bump = [ctx.bumps.collateral1_vault];
+        let collateral1_seeds = &[
+            COLLATERAL_VAULT_SEED_PREFIX,
+            pair_key.as_ref(),
+            token1.as_ref(),
+            collateral1_bump.as_ref(),
+        ];
+        create_token_account(
+            &pair.to_account_info(),
+            &ctx.accounts.deployer.to_account_info(),
+            &ctx.accounts.collateral1_vault.to_account_info(),
+            &ctx.accounts.token1_mint.to_account_info(),
+            &ctx.accounts.system_program.to_account_info(),
+            &token1_program,
+            collateral1_seeds,
+        )?;
+
+        let amount0_transfer_in =
+            amount_with_transfer_fee(&ctx.accounts.token0_mint.to_account_info(), amount0_in)?;
+        let amount1_transfer_in =
+            amount_with_transfer_fee(&ctx.accounts.token1_mint.to_account_info(), amount1_in)?;
+
         // Transfer tokens from deployer to vaults
         transfer_from_user_to_vault(
             ctx.accounts.deployer.to_account_info(),
             ctx.accounts.deployer_token0_account.to_account_info(),
             ctx.accounts.reserve0_vault.to_account_info(),
             ctx.accounts.token0_mint.to_account_info(),
-            match ctx.accounts.token0_mint.to_account_info().owner == ctx.accounts.token_program.key {
-                true => ctx.accounts.token_program.to_account_info(),
-                false => ctx.accounts.token_2022_program.to_account_info(),
-            },
-            amount0_in,
+            token0_program,
+            amount0_transfer_in,
             ctx.accounts.token0_mint.decimals,
         )?;
 
@@ -431,24 +525,21 @@ impl<'info> InitializeAndBootstrap<'info> {
             ctx.accounts.deployer_token1_account.to_account_info(),
             ctx.accounts.reserve1_vault.to_account_info(),
             ctx.accounts.token1_mint.to_account_info(),
-            match ctx.accounts.token1_mint.to_account_info().owner == ctx.accounts.token_program.key {
-                true => ctx.accounts.token_program.to_account_info(),
-                false => ctx.accounts.token_2022_program.to_account_info(),
-            },
-            amount1_in,
+            token1_program,
+            amount1_transfer_in,
             ctx.accounts.token1_mint.decimals,
         )?;
-        
+
         // Initialize LP mint
         require!(
             ctx.accounts.lp_mint.data_len() == 82,
             ErrorCode::InvalidMintLen
         );
         let mint_unchecked = spl_token::state::Mint::unpack_unchecked(
-            &ctx.accounts.lp_mint.to_account_info().data.borrow()
+            &ctx.accounts.lp_mint.to_account_info().data.borrow(),
         )?;
         require!(!mint_unchecked.is_initialized, ErrorCode::AccountNotEmpty);
-        
+
         let ix = spl_token::instruction::initialize_mint2(
             &ctx.accounts.token_program.key(),
             &ctx.accounts.lp_mint.key(),
@@ -456,64 +547,64 @@ impl<'info> InitializeAndBootstrap<'info> {
             None,
             9,
         )?;
-        invoke(
-            &ix,
-            &[
-                ctx.accounts.lp_mint.to_account_info(),
-            ],
-        )?;
+        invoke(&ix, &[ctx.accounts.lp_mint.to_account_info()])?;
 
         // lp mint post-initialize checks
         let lp_mint_account = ctx.accounts.lp_mint.to_account_info();
         let mint = spl_token::state::Mint::unpack(&lp_mint_account.data.borrow())?;
-        require_keys_eq!(mint.mint_authority.unwrap(), pair_key, ErrorCode::InvalidMintAuthority);
+        require_keys_eq!(
+            mint.mint_authority.unwrap(),
+            pair_key,
+            ErrorCode::InvalidMintAuthority
+        );
         require!(mint.freeze_authority.is_none(), ErrorCode::FrozenLpMint);
         require!(mint.supply == 0, ErrorCode::NonZeroSupply);
         require_eq!(mint.decimals, 9, ErrorCode::WrongLpDecimals);
 
         // Create associated token account for deployer LP token
-        create_idempotent(
-            CpiContext::new(
-                ctx.accounts.associated_token_program.to_account_info(),
-                anchor_spl::associated_token::Create {
-                    payer: ctx.accounts.deployer.to_account_info(),
-                    associated_token: ctx.accounts.deployer_lp_token_account.to_account_info(),
-                    authority: ctx.accounts.deployer.to_account_info(),
-                    mint: ctx.accounts.lp_mint.to_account_info(),
-                    system_program: ctx.accounts.system_program.to_account_info(),
-                    token_program: ctx.accounts.token_program.to_account_info(),
-                },
-            ),
-        )?;
-        
+        create_idempotent(CpiContext::new(
+            ctx.accounts.associated_token_program.to_account_info(),
+            anchor_spl::associated_token::Create {
+                payer: ctx.accounts.deployer.to_account_info(),
+                associated_token: ctx.accounts.deployer_lp_token_account.to_account_info(),
+                authority: ctx.accounts.deployer.to_account_info(),
+                mint: ctx.accounts.lp_mint.to_account_info(),
+                system_program: ctx.accounts.system_program.to_account_info(),
+                token_program: ctx.accounts.token_program.to_account_info(),
+            },
+        ))?;
+
         // --- Create Metaplex metadata for LP mint ---
         let data = DataV2 {
-            name:   lp_name.clone(),
+            name: lp_name.clone(),
             symbol: lp_symbol.clone(),
-            uri:    lp_uri.clone(),
+            uri: lp_uri.clone(),
             seller_fee_basis_points: 0,
             creators: None,
             collection: None,
             uses: None,
         };
-        
+
         let cpi_accounts = CreateMetadataAccountsV3 {
-            metadata:         ctx.accounts.lp_token_metadata.to_account_info(),
-            mint:             ctx.accounts.lp_mint.to_account_info(),
-            mint_authority:   pair.to_account_info(),   // pair PDA signs
-            payer:            ctx.accounts.deployer.to_account_info(),
-            update_authority: pair.to_account_info(),   // keep program-controlled
-            system_program:   ctx.accounts.system_program.to_account_info(),
-            rent:             ctx.accounts.rent.to_account_info(),
+            metadata: ctx.accounts.lp_token_metadata.to_account_info(),
+            mint: ctx.accounts.lp_mint.to_account_info(),
+            mint_authority: pair.to_account_info(), // pair PDA signs
+            payer: ctx.accounts.deployer.to_account_info(),
+            update_authority: pair.to_account_info(), // keep program-controlled
+            system_program: ctx.accounts.system_program.to_account_info(),
+            rent: ctx.accounts.rent.to_account_info(),
         };
-        
+
         create_metadata_accounts_v3(
-            CpiContext::new(ctx.accounts.token_metadata_program.to_account_info(), cpi_accounts)
-                .with_signer(&[&generate_gamm_pair_seeds!(pair)[..]]),
+            CpiContext::new(
+                ctx.accounts.token_metadata_program.to_account_info(),
+                cpi_accounts,
+            )
+            .with_signer(&[&generate_gamm_pair_seeds!(pair)[..]]),
             data,
-            true,  // is_mutable
-            true,  // update_authority_is_signer (pair PDA)
-            None,  // token_standard
+            true, // is_mutable
+            true, // update_authority_is_signer (pair PDA)
+            None, // token_standard
         )?;
 
         // Calculate liquidity
@@ -533,11 +624,8 @@ impl<'info> InitializeAndBootstrap<'info> {
             .try_into()
             .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
 
-        require!(
-            liquidity >= min_liquidity_out,
-            ErrorCode::SlippageExceeded
-        );
-        
+        require!(liquidity >= min_liquidity_out, ErrorCode::SlippageExceeded);
+
         // Mint LP tokens to deployer
         token_mint_to(
             pair.to_account_info(),
@@ -545,17 +633,20 @@ impl<'info> InitializeAndBootstrap<'info> {
             ctx.accounts.lp_mint.to_account_info(),
             ctx.accounts.deployer_lp_token_account.to_account_info(),
             liquidity,
-            &[&generate_gamm_pair_seeds!(pair)[..]]
+            &[&generate_gamm_pair_seeds!(pair)[..]],
         )?;
-        
+
         // Update reserves
-        pair.reserve0 = pair.reserve0
+        pair.reserve0 = pair
+            .reserve0
             .checked_add(amount0_in)
             .ok_or(ErrorCode::ReserveOverflow)?;
-        pair.reserve1 = pair.reserve1
+        pair.reserve1 = pair
+            .reserve1
             .checked_add(amount1_in)
             .ok_or(ErrorCode::ReserveOverflow)?;
-        pair.total_supply = pair.total_supply
+        pair.total_supply = pair
+            .total_supply
             .checked_add(liquidity)
             .ok_or(ErrorCode::SupplyOverflow)?;
 
@@ -627,8 +718,7 @@ impl<'info> InitializeAndBootstrap<'info> {
             token1_mint: pair.token1,
             lp_mint: ctx.accounts.lp_mint.key(),
         });
-        
 
         Ok(())
-    }   
+    }
 }

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -408,11 +408,11 @@ fn validate_post_withdraw_debt_coverage_with_prices(
     )?;
 
     require!(
-        (post_reserve1 as u128) >= with_debt_coverage_buffer(required_token1_for_debt0)?,
+        (post_reserve1 as u128) >= with_required_debt_coverage(required_token1_for_debt0)?,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
     require!(
-        (post_reserve0 as u128) >= with_debt_coverage_buffer(required_token0_for_debt1)?,
+        (post_reserve0 as u128) >= with_required_debt_coverage(required_token0_for_debt1)?,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
 
@@ -451,7 +451,7 @@ fn required_collateral_with_impact(
     CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_amount)
 }
 
-fn with_debt_coverage_buffer(amount: u64) -> Result<u128> {
+fn with_required_debt_coverage(amount: u64) -> Result<u128> {
     ceil_div(
         (amount as u128)
             .checked_mul(POST_WITHDRAW_DEBT_COVERAGE_BPS as u128)
@@ -466,7 +466,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_passes_with_coverage_buffer() {
+    fn liquidity_delta_withdrawal_solvency_passes_with_required_coverage() {
         validate_post_withdraw_debt_coverage_with_prices(
             1_000, 1_000, 100, 100, NAD, NAD, NAD, NAD,
         )
@@ -474,7 +474,15 @@ mod tests {
     }
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_fails_without_coverage_buffer() {
+    fn liquidity_delta_withdrawal_solvency_accepts_exact_debt_coverage() {
+        validate_post_withdraw_debt_coverage_with_prices(
+            1_000, 1_000, 500, 0, NAD, NAD, NAD, NAD,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn liquidity_delta_withdrawal_solvency_fails_without_required_coverage() {
         let err = validate_post_withdraw_debt_coverage_with_prices(
             1_000, 1_000, 900, 0, NAD, NAD, NAD, NAD,
         )

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -385,11 +385,11 @@ fn validate_post_withdraw_debt_coverage_with_prices(
     )?;
 
     require!(
-        (post_reserve1 as u128) >= with_required_debt_coverage(required_token1_for_debt0)?,
+        (post_reserve1 as u128) >= with_debt_coverage_buffer(required_token1_for_debt0)?,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
     require!(
-        (post_reserve0 as u128) >= with_required_debt_coverage(required_token0_for_debt1)?,
+        (post_reserve0 as u128) >= with_debt_coverage_buffer(required_token0_for_debt1)?,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
 
@@ -428,7 +428,7 @@ fn required_collateral_with_impact(
     CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_amount)
 }
 
-fn with_required_debt_coverage(amount: u64) -> Result<u128> {
+fn with_debt_coverage_buffer(amount: u64) -> Result<u128> {
     ceil_div(
         (amount as u128)
             .checked_mul(POST_WITHDRAW_DEBT_COVERAGE_BPS as u128)
@@ -443,7 +443,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_passes_with_required_coverage() {
+    fn liquidity_delta_withdrawal_solvency_passes_with_coverage_buffer() {
         validate_post_withdraw_debt_coverage_with_prices(
             1_000, 1_000, 100, 100, NAD, NAD, NAD, NAD,
         )
@@ -451,15 +451,17 @@ mod tests {
     }
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_accepts_exact_debt_coverage() {
-        validate_post_withdraw_debt_coverage_with_prices(
+    fn liquidity_delta_withdrawal_solvency_fails_at_exact_debt_coverage_without_buffer() {
+        let err = validate_post_withdraw_debt_coverage_with_prices(
             1_000, 1_000, 500, 0, NAD, NAD, NAD, NAD,
         )
-        .unwrap();
+        .unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
     }
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_fails_without_required_coverage() {
+    fn liquidity_delta_withdrawal_solvency_fails_without_coverage_buffer() {
         let err = validate_post_withdraw_debt_coverage_with_prices(
             1_000, 1_000, 900, 0, NAD, NAD, NAD, NAD,
         )

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -11,7 +11,6 @@ use crate::errors::ErrorCode;
 use crate::events::{BurnEvent, EventMetadata, UserLiquidityPositionUpdatedEvent};
 use crate::generate_gamm_pair_seeds;
 use crate::state::{futarchy_authority::FutarchyAuthority, pair::Pair, rate_model::RateModel};
-use crate::utils::gamm_math::{construct_virtual_reserves_at_pessimistic_price, CPCurve};
 use crate::utils::liquidity_delta_circuit_breaker::{
     require_no_same_tx_add_liquidity, require_top_level_liquidity_delta_ix,
     LiquidityDeltaInstruction,
@@ -353,9 +352,7 @@ fn validate_post_withdraw_debt_coverage(
         pair.total_debt0,
         pair.total_debt1,
         pair.ema_price0_nad(),
-        pair.directional_ema_price0_nad(),
         pair.ema_price1_nad(),
-        pair.directional_ema_price1_nad(),
     )
 }
 
@@ -365,77 +362,46 @@ fn validate_post_withdraw_debt_coverage_with_prices(
     total_debt0: u64,
     total_debt1: u64,
     token0_ema_price_nad: u64,
-    token0_directional_ema_price_nad: u64,
     token1_ema_price_nad: u64,
-    token1_directional_ema_price_nad: u64,
 ) -> Result<()> {
-    let required_token1_for_debt0 = required_collateral_with_impact(
-        total_debt0,
-        post_reserve1,
-        post_reserve0,
-        token1_ema_price_nad,
-        token1_directional_ema_price_nad,
-    )?;
-    let required_token0_for_debt1 = required_collateral_with_impact(
-        total_debt1,
-        post_reserve0,
-        post_reserve1,
-        token0_ema_price_nad,
-        token0_directional_ema_price_nad,
-    )?;
+    let required_token1_for_debt0 =
+        required_collateral_at_reference_price(total_debt0, token1_ema_price_nad)?;
+    let required_token0_for_debt1 =
+        required_collateral_at_reference_price(total_debt1, token0_ema_price_nad)?;
 
     require!(
-        (post_reserve1 as u128) >= with_debt_coverage_buffer(required_token1_for_debt0)?,
+        post_reserve1 >= required_token1_for_debt0,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
     require!(
-        (post_reserve0 as u128) >= with_debt_coverage_buffer(required_token0_for_debt1)?,
+        post_reserve0 >= required_token0_for_debt1,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
 
     Ok(())
 }
 
-fn required_collateral_with_impact(
+fn required_collateral_at_reference_price(
     debt_amount: u64,
-    collateral_spot_reserve: u64,
-    debt_spot_reserve: u64,
     collateral_ema_price_nad: u64,
-    collateral_directional_ema_price_nad: u64,
 ) -> Result<u64> {
     if debt_amount == 0 {
         return Ok(0);
     }
 
     require!(
-        collateral_ema_price_nad > 0 && collateral_directional_ema_price_nad > 0,
+        collateral_ema_price_nad > 0,
         ErrorCode::InsufficientPostWithdrawDebtCoverage
     );
 
-    let (collateral_ema_reserve, debt_ema_reserve) =
-        construct_virtual_reserves_at_pessimistic_price(
-            collateral_spot_reserve,
-            debt_spot_reserve,
-            collateral_ema_price_nad,
-            collateral_directional_ema_price_nad,
-        )?;
-
-    require!(
-        collateral_ema_reserve > 0 && debt_ema_reserve > debt_amount,
-        ErrorCode::InsufficientPostWithdrawDebtCoverage
-    );
-
-    CPCurve::calculate_amount_in(collateral_ema_reserve, debt_ema_reserve, debt_amount)
-}
-
-fn with_debt_coverage_buffer(amount: u64) -> Result<u128> {
-    ceil_div(
-        (amount as u128)
-            .checked_mul(POST_WITHDRAW_DEBT_COVERAGE_BPS as u128)
+    let required = ceil_div(
+        (debt_amount as u128)
+            .checked_mul(NAD as u128)
             .ok_or(ErrorCode::DebtMathOverflow)?,
-        BPS_DENOMINATOR as u128,
+        collateral_ema_price_nad as u128,
     )
-    .ok_or(ErrorCode::DebtMathOverflow.into())
+    .ok_or(ErrorCode::DebtMathOverflow)?;
+    u64::try_from(required).map_err(|_| ErrorCode::DebtMathOverflow.into())
 }
 
 #[cfg(test)]
@@ -443,39 +409,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_passes_with_coverage_buffer() {
-        validate_post_withdraw_debt_coverage_with_prices(
-            1_000, 1_000, 100, 100, NAD, NAD, NAD, NAD,
-        )
-        .unwrap();
+    fn liquidity_delta_withdrawal_solvency_passes_at_exact_reference_coverage() {
+        validate_post_withdraw_debt_coverage_with_prices(1_000, 500, 500, 0, NAD, NAD)
+            .unwrap();
     }
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_fails_at_exact_debt_coverage_without_buffer() {
-        let err = validate_post_withdraw_debt_coverage_with_prices(
-            1_000, 1_000, 500, 0, NAD, NAD, NAD, NAD,
-        )
-        .unwrap_err();
+    fn liquidity_delta_withdrawal_solvency_uses_linear_reference_price_not_impact() {
+        validate_post_withdraw_debt_coverage_with_prices(1_000, 1_000, 900, 0, NAD, NAD)
+            .unwrap();
+    }
+
+    #[test]
+    fn liquidity_delta_withdrawal_solvency_fails_below_reference_coverage() {
+        let err =
+            validate_post_withdraw_debt_coverage_with_prices(1_000, 499, 500, 0, NAD, NAD)
+                .unwrap_err();
 
         assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
     }
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_fails_without_coverage_buffer() {
-        let err = validate_post_withdraw_debt_coverage_with_prices(
-            1_000, 1_000, 900, 0, NAD, NAD, NAD, NAD,
-        )
-        .unwrap_err();
-
-        assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
-    }
-
-    #[test]
-    fn liquidity_delta_withdrawal_solvency_fails_with_zero_pessimistic_price() {
-        let err = validate_post_withdraw_debt_coverage_with_prices(
-            1_000, 1_000, 100, 0, NAD, NAD, NAD, 0,
-        )
-        .unwrap_err();
+    fn liquidity_delta_withdrawal_solvency_fails_with_zero_reference_price() {
+        let err =
+            validate_post_withdraw_debt_coverage_with_prices(1_000, 1_000, 100, 0, NAD, 0)
+                .unwrap_err();
 
         assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
     }

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -2,8 +2,8 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::sysvar;
 use anchor_spl::{
     associated_token::AssociatedToken,
-    token::{Mint, Token, TokenAccount},
-    token_interface::Token2022,
+    token::{Mint as SplMint, Token, TokenAccount as SplTokenAccount},
+    token_interface::{Mint, Token2022, TokenAccount},
 };
 
 use crate::constants::*;
@@ -16,7 +16,9 @@ use crate::utils::liquidity_delta_circuit_breaker::{
     LiquidityDeltaInstruction,
 };
 use crate::utils::math::ceil_div;
-use crate::utils::token::{token_burn, transfer_from_vault_to_user};
+use crate::utils::token::{
+    amount_after_transfer_fee, token_burn, token_program_for_mint, transfer_from_vault_to_user,
+};
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct RemoveLiquidityArgs {
@@ -61,7 +63,7 @@ pub struct RemoveLiquidity<'info> {
         ],
         bump = pair.vault_bumps.reserve0
     )]
-    pub reserve0_vault: Box<Account<'info, TokenAccount>>,
+    pub reserve0_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
@@ -72,37 +74,37 @@ pub struct RemoveLiquidity<'info> {
         ],
         bump = pair.vault_bumps.reserve1
     )]
-    pub reserve1_vault: Box<Account<'info, TokenAccount>>,
+    pub reserve1_vault: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
-        token::mint = pair.token0,
-        token::authority = user,
+        constraint = user_token0_account.mint == pair.token0 @ ErrorCode::InvalidTokenAccount,
+        constraint = user_token0_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_token0_account: Box<Account<'info, TokenAccount>>,
+    pub user_token0_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         mut,
-        token::mint = pair.token1,
-        token::authority = user,
+        constraint = user_token1_account.mint == pair.token1 @ ErrorCode::InvalidTokenAccount,
+        constraint = user_token1_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_token1_account: Box<Account<'info, TokenAccount>>,
+    pub user_token1_account: Box<InterfaceAccount<'info, TokenAccount>>,
 
     #[account(
         address = pair.token0 @ ErrorCode::InvalidMint
     )]
-    pub token0_mint: Box<Account<'info, Mint>>,
+    pub token0_mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         address = pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub token1_mint: Box<Account<'info, Mint>>,
+    pub token1_mint: Box<InterfaceAccount<'info, Mint>>,
 
     #[account(
         mut,
         address = pair.lp_mint @ ErrorCode::InvalidMint,
     )]
-    pub lp_mint: Box<Account<'info, Mint>>,
+    pub lp_mint: Box<Account<'info, SplMint>>,
 
     #[account(
         init_if_needed,
@@ -111,7 +113,7 @@ pub struct RemoveLiquidity<'info> {
         payer = user,
         token::token_program = token_program,
     )]
-    pub user_lp_token_account: Box<Account<'info, TokenAccount>>,
+    pub user_lp_token_account: Box<Account<'info, SplTokenAccount>>,
 
     #[account(mut)]
     pub user: Signer<'info>,
@@ -200,13 +202,18 @@ impl<'info> RemoveLiquidity<'info> {
             .try_into()
             .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
 
+        let amount0_user_out =
+            amount_after_transfer_fee(&token0_mint.to_account_info(), amount0_out)?;
+        let amount1_user_out =
+            amount_after_transfer_fee(&token1_mint.to_account_info(), amount1_out)?;
+
         // Check if amounts meet minimum (slippage protection)
         require!(
-            amount0_out >= args.min_amount0_out,
+            amount0_user_out >= args.min_amount0_out,
             ErrorCode::SlippageExceeded
         );
         require!(
-            amount1_out >= args.min_amount1_out,
+            amount1_user_out >= args.min_amount1_out,
             ErrorCode::SlippageExceeded
         );
 
@@ -242,10 +249,11 @@ impl<'info> RemoveLiquidity<'info> {
             reserve0_vault.to_account_info(),
             user_token0_account.to_account_info(),
             token0_mint.to_account_info(),
-            match token0_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
+            token_program_for_mint(
+                &token0_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
             amount0_out,
             token0_mint.decimals,
             &[&generate_gamm_pair_seeds!(pair)[..]],
@@ -256,10 +264,11 @@ impl<'info> RemoveLiquidity<'info> {
             reserve1_vault.to_account_info(),
             user_token1_account.to_account_info(),
             token1_mint.to_account_info(),
-            match token1_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
+            token_program_for_mint(
+                &token1_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
             amount1_out,
             token1_mint.decimals,
             &[&generate_gamm_pair_seeds!(pair)[..]],
@@ -410,30 +419,26 @@ mod tests {
 
     #[test]
     fn liquidity_delta_withdrawal_solvency_passes_at_exact_reference_coverage() {
-        validate_post_withdraw_debt_coverage_with_prices(1_000, 500, 500, 0, NAD, NAD)
-            .unwrap();
+        validate_post_withdraw_debt_coverage_with_prices(1_000, 500, 500, 0, NAD, NAD).unwrap();
     }
 
     #[test]
     fn liquidity_delta_withdrawal_solvency_uses_linear_reference_price_not_impact() {
-        validate_post_withdraw_debt_coverage_with_prices(1_000, 1_000, 900, 0, NAD, NAD)
-            .unwrap();
+        validate_post_withdraw_debt_coverage_with_prices(1_000, 1_000, 900, 0, NAD, NAD).unwrap();
     }
 
     #[test]
     fn liquidity_delta_withdrawal_solvency_fails_below_reference_coverage() {
-        let err =
-            validate_post_withdraw_debt_coverage_with_prices(1_000, 499, 500, 0, NAD, NAD)
-                .unwrap_err();
+        let err = validate_post_withdraw_debt_coverage_with_prices(1_000, 499, 500, 0, NAD, NAD)
+            .unwrap_err();
 
         assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
     }
 
     #[test]
     fn liquidity_delta_withdrawal_solvency_fails_with_zero_reference_price() {
-        let err =
-            validate_post_withdraw_debt_coverage_with_prices(1_000, 1_000, 100, 0, NAD, 0)
-                .unwrap_err();
+        let err = validate_post_withdraw_debt_coverage_with_prices(1_000, 1_000, 100, 0, NAD, 0)
+            .unwrap_err();
 
         assert_eq!(err, error!(ErrorCode::InsufficientPostWithdrawDebtCoverage));
     }

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -235,10 +235,6 @@ impl<'info> RemoveLiquidity<'info> {
             .reserve1
             .checked_sub(amount1_out)
             .ok_or(ErrorCode::ReserveUnderflow)?;
-        // LP withdrawal changes the pool's remaining debt coverage, so use the
-        // pessimistic directional EMA to prevent withdrawing against stale high
-        // symmetric EMA after spot falls. This is separate from liquidation, which
-        // uses symmetric EMA to avoid dump-spot-and-liquidate attacks.
         validate_post_withdraw_debt_coverage(pair, post_reserve0, post_reserve1)?;
 
         // Transfer tokens from pool to user

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -184,45 +184,22 @@ impl<'info> RemoveLiquidity<'info> {
             ..
         } = ctx.accounts;
 
-        // Calculate amounts to remove (before fee)
+        // Calculate amounts to remove
         let total_supply = pair.total_supply;
-        let amount0_gross: u64 = (args.liquidity_in as u128)
+        let amount0_out: u64 = (args.liquidity_in as u128)
             .checked_mul(pair.reserve0 as u128)
             .ok_or(ErrorCode::LiquidityMathOverflow)?
             .checked_div(total_supply as u128)
             .ok_or(ErrorCode::LiquidityMathOverflow)?
             .try_into()
             .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
-        let amount1_gross: u64 = (args.liquidity_in as u128)
+        let amount1_out: u64 = (args.liquidity_in as u128)
             .checked_mul(pair.reserve1 as u128)
             .ok_or(ErrorCode::LiquidityMathOverflow)?
             .checked_div(total_supply as u128)
             .ok_or(ErrorCode::LiquidityMathOverflow)?
             .try_into()
             .map_err(|_| ErrorCode::LiquidityConversionOverflow)?;
-
-        // Apply withdrawal fee (1%) - fee remains in reserves for remaining LPs
-        let fee0 = ceil_div(
-            (amount0_gross as u128)
-                .checked_mul(LIQUIDITY_WITHDRAWAL_FEE_BPS as u128)
-                .ok_or(ErrorCode::FeeMathOverflow)?,
-            BPS_DENOMINATOR as u128,
-        )
-        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
-        let fee1 = ceil_div(
-            (amount1_gross as u128)
-                .checked_mul(LIQUIDITY_WITHDRAWAL_FEE_BPS as u128)
-                .ok_or(ErrorCode::FeeMathOverflow)?,
-            BPS_DENOMINATOR as u128,
-        )
-        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
-
-        let amount0_out = amount0_gross
-            .checked_sub(fee0)
-            .ok_or(ErrorCode::LiquidityMathOverflow)?;
-        let amount1_out = amount1_gross
-            .checked_sub(fee1)
-            .ok_or(ErrorCode::LiquidityMathOverflow)?;
 
         // Check if amounts meet minimum (slippage protection)
         require!(
@@ -502,17 +479,9 @@ mod tests {
     }
 
     #[test]
-    fn liquidity_delta_withdrawal_solvency_accounts_for_fee_remaining_in_reserves() {
-        let gross = 100_u64;
-        let fee = ceil_div(
-            (gross as u128) * (LIQUIDITY_WITHDRAWAL_FEE_BPS as u128),
-            BPS_DENOMINATOR as u128,
-        )
-        .unwrap() as u64;
-        let amount_out = gross - fee;
+    fn liquidity_delta_withdrawal_solvency_charges_no_withdrawal_fee() {
+        let amount_out = 100_u64;
 
-        assert_eq!(fee, 1);
-        assert_eq!(amount_out, 99);
-        assert_eq!(1_000_u64 - amount_out, 901);
+        assert_eq!(1_000_u64 - amount_out, 900);
     }
 }

--- a/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
+++ b/programs/omnipair/src/instructions/liquidity/remove_liquidity.rs
@@ -235,6 +235,10 @@ impl<'info> RemoveLiquidity<'info> {
             .reserve1
             .checked_sub(amount1_out)
             .ok_or(ErrorCode::ReserveUnderflow)?;
+        // LP withdrawal changes the pool's remaining debt coverage, so use the
+        // pessimistic directional EMA to prevent withdrawing against stale high
+        // symmetric EMA after spot falls. This is separate from liquidation, which
+        // uses symmetric EMA to avoid dump-spot-and-liquidate attacks.
         validate_post_withdraw_debt_coverage(pair, post_reserve0, post_reserve1)?;
 
         // Transfer tokens from pool to user

--- a/programs/omnipair/src/instructions/mod.rs
+++ b/programs/omnipair/src/instructions/mod.rs
@@ -11,5 +11,6 @@ pub use lending::add_collateral::*;
 pub use lending::borrow::*;
 pub use lending::liquidate::*;
 pub use lending::flashloan::*;
+pub use lending::transfer_user_position::*;
 pub use futarchy::*;
 pub use emit_value::*;

--- a/programs/omnipair/src/instructions/spot/swap.rs
+++ b/programs/omnipair/src/instructions/spot/swap.rs
@@ -1,19 +1,21 @@
-use anchor_lang::prelude::*;
-use anchor_spl::{
-    token::{Token, TokenAccount, Mint},
-    token_interface::{Token2022},
-};
 use crate::{
-    state::*,
     constants::*,
     errors::ErrorCode,
     events::*,
-    utils::token::{transfer_from_user_to_vault, transfer_from_vault_to_user},
+    generate_gamm_pair_seeds,
+    state::*,
     utils::gamm_math::CPCurve,
     utils::math::ceil_div,
-    generate_gamm_pair_seeds,
+    utils::token::{
+        amount_after_transfer_fee, token_program_for_mint, transfer_from_user_to_vault,
+        transfer_from_vault_to_user,
+    },
 };
-
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    token::Token,
+    token_interface::{Mint, Token2022, TokenAccount},
+};
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct SwapArgs {
@@ -23,7 +25,7 @@ pub struct SwapArgs {
 
 #[event_cpi]
 #[derive(Accounts)]
-pub struct Swap<'info> { 
+pub struct Swap<'info> {
     #[account(
         mut,
         seeds = [PAIR_SEED_PREFIX, pair.token0.as_ref(), pair.token1.as_ref(), pair.params_hash.as_ref()],
@@ -43,7 +45,7 @@ pub struct Swap<'info> {
         bump = futarchy_authority.bump
     )]
     pub futarchy_authority: Account<'info, FutarchyAuthority>,
-    
+
     #[account(
         mut,
         seeds = [
@@ -53,8 +55,8 @@ pub struct Swap<'info> {
         ],
         bump = pair.get_reserve_vault_bump(&token_in_mint.key())
     )]
-    pub token_in_vault: Account<'info, TokenAccount>,
-    
+    pub token_in_vault: InterfaceAccount<'info, TokenAccount>,
+
     #[account(
         mut,
         seeds = [
@@ -64,29 +66,29 @@ pub struct Swap<'info> {
         ],
         bump = pair.get_reserve_vault_bump(&token_out_mint.key())
     )]
-    pub token_out_vault: Account<'info, TokenAccount>,
-    
+    pub token_out_vault: InterfaceAccount<'info, TokenAccount>,
+
     #[account(
         mut,
         constraint = user_token_in_account.mint == token_in_mint.key() @ ErrorCode::InvalidTokenAccount,
-        token::authority = user,
+        constraint = user_token_in_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_token_in_account: Account<'info, TokenAccount>,
+    pub user_token_in_account: InterfaceAccount<'info, TokenAccount>,
     #[account(mut,
         constraint = user_token_out_account.mint == token_out_mint.key() @ ErrorCode::InvalidTokenAccount,
-        token::authority = user,
+        constraint = user_token_out_account.owner == user.key() @ ErrorCode::InvalidTokenAccount,
     )]
-    pub user_token_out_account: Account<'info, TokenAccount>,
+    pub user_token_out_account: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         constraint = token_in_mint.key() == pair.token0 || token_in_mint.key() == pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub token_in_mint: Box<Account<'info, Mint>>,
+    pub token_in_mint: Box<InterfaceAccount<'info, Mint>>,
     #[account(
         constraint = token_out_mint.key() == pair.token0 || token_out_mint.key() == pair.token1 @ ErrorCode::InvalidMint
     )]
-    pub token_out_mint: Box<Account<'info, Mint>>,
-    
+    pub token_out_mint: Box<InterfaceAccount<'info, Mint>>,
+
     pub user: Signer<'info>,
     pub token_program: Program<'info, Token>,
     pub token_2022_program: Program<'info, Token2022>,
@@ -97,18 +99,22 @@ impl<'info> Swap<'info> {
         let amount_in = args.amount_in;
 
         require!(amount_in > 0, ErrorCode::AmountZero);
-        require_gte!(self.user_token_in_account.amount, amount_in, ErrorCode::InsufficientBalance);
-        
+        require_gte!(
+            self.user_token_in_account.amount,
+            amount_in,
+            ErrorCode::InsufficientBalance
+        );
+
         // Ensure token_in_vault and token_out_vault are different accounts
         require_keys_neq!(
             self.token_in_vault.key(),
             self.token_out_vault.key(),
             ErrorCode::InvalidVaultSameAccount
         );
-        
+
         // Verify vaults match the correct tokens based on swap direction
         let is_token0_in = self.user_token_in_account.mint == self.pair.token0;
-        
+
         if is_token0_in {
             // Swapping token0 -> token1
             require_keys_eq!(
@@ -134,7 +140,7 @@ impl<'info> Swap<'info> {
                 ErrorCode::InvalidTokenAccount
             );
         }
-        
+
         Ok(())
     }
 
@@ -156,7 +162,10 @@ impl<'info> Swap<'info> {
     }
 
     pub fn handle_swap(ctx: Context<Self>, args: SwapArgs) -> Result<()> {
-        let SwapArgs { amount_in, min_amount_out } = args;
+        let SwapArgs {
+            amount_in,
+            min_amount_out,
+        } = args;
         let Swap {
             pair,
             futarchy_authority,
@@ -171,43 +180,79 @@ impl<'info> Swap<'info> {
             user,
             ..
         } = ctx.accounts;
-        let last_k = (pair.reserve0 as u128).checked_mul(pair.reserve1 as u128).ok_or(ErrorCode::InvariantOverflow)?;
+        let last_k = (pair.reserve0 as u128)
+            .checked_mul(pair.reserve1 as u128)
+            .ok_or(ErrorCode::InvariantOverflow)?;
         let is_token0_in = user_token_in_account.mint == pair.token0;
+        let amount_in_received =
+            amount_after_transfer_fee(&token_in_mint.to_account_info(), amount_in)?;
+        require!(amount_in_received > 0, ErrorCode::AmountZero);
 
         // Swap fee = LP fee + Futarchy fee
-        let swap_fee = ceil_div((amount_in as u128)
-            .checked_mul(pair.swap_fee_bps as u128)
-            .ok_or(ErrorCode::FeeMathOverflow)?,
+        let swap_fee = ceil_div(
+            (amount_in_received as u128)
+                .checked_mul(pair.swap_fee_bps as u128)
+                .ok_or(ErrorCode::FeeMathOverflow)?,
             BPS_DENOMINATOR as u128,
-        ).ok_or(ErrorCode::FeeMathOverflow)? as u64;
+        )
+        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
 
         // Calculate futarchy fee portion of the swap fee
-        let futarchy_fee = ceil_div((swap_fee as u128)
-            .checked_mul(futarchy_authority.revenue_share.swap_bps as u128)
-            .ok_or(ErrorCode::FeeMathOverflow)?,
+        let futarchy_fee = ceil_div(
+            (swap_fee as u128)
+                .checked_mul(futarchy_authority.revenue_share.swap_bps as u128)
+                .ok_or(ErrorCode::FeeMathOverflow)?,
             BPS_DENOMINATOR as u128,
-        ).ok_or(ErrorCode::FeeMathOverflow)? as u64;
+        )
+        .ok_or(ErrorCode::FeeMathOverflow)? as u64;
 
         // amount_in_after_swap_fee = amount_in - swap_fee
-        let amount_in_after_swap_fee = amount_in.checked_sub(swap_fee).ok_or(ErrorCode::FeeMathOverflow)?;
+        let amount_in_after_swap_fee = amount_in_received
+            .checked_sub(swap_fee)
+            .ok_or(ErrorCode::FeeMathOverflow)?;
 
-        let reserve_in = if is_token0_in { pair.reserve0 } else { pair.reserve1 };
-        let reserve_out = if is_token0_in { pair.reserve1 } else { pair.reserve0 };
+        let reserve_in = if is_token0_in {
+            pair.reserve0
+        } else {
+            pair.reserve1
+        };
+        let reserve_out = if is_token0_in {
+            pair.reserve1
+        } else {
+            pair.reserve0
+        };
 
         // Δy = (Δx * y) / (x + Δx)
-        let amount_out = CPCurve::calculate_amount_out(reserve_in, reserve_out, amount_in_after_swap_fee)?;
+        let amount_out =
+            CPCurve::calculate_amount_out(reserve_in, reserve_out, amount_in_after_swap_fee)?;
 
         // Calculate the amount in with the LP portion of the fee:
         // amount_in_with_lp_fee = amount_in - swap_fee + lp_fee = amount_in - futarchy_fee
-        let amount_in_with_lp_fee = amount_in.checked_sub(futarchy_fee).ok_or(ErrorCode::Overflow)?;
-        let new_reserve_in = reserve_in.checked_add(amount_in_with_lp_fee).ok_or(ErrorCode::Overflow)?;
-        let new_reserve_out = reserve_out.checked_sub(amount_out).ok_or(ErrorCode::Overflow)?;
+        let amount_in_with_lp_fee = amount_in_received
+            .checked_sub(futarchy_fee)
+            .ok_or(ErrorCode::Overflow)?;
+        let new_reserve_in = reserve_in
+            .checked_add(amount_in_with_lp_fee)
+            .ok_or(ErrorCode::Overflow)?;
+        let new_reserve_out = reserve_out
+            .checked_sub(amount_out)
+            .ok_or(ErrorCode::Overflow)?;
+        let amount_out_user =
+            amount_after_transfer_fee(&token_out_mint.to_account_info(), amount_out)?;
 
-        require_gte!(amount_out, min_amount_out, ErrorCode::SlippageExceeded);
+        require_gte!(amount_out_user, min_amount_out, ErrorCode::SlippageExceeded);
         // 1. r_cash >= r_out
         match is_token0_in {
-            true => require_gte!(pair.cash_reserve1, amount_out, ErrorCode::InsufficientCashReserve1),
-            false => require_gte!(pair.cash_reserve0, amount_out, ErrorCode::InsufficientCashReserve0),
+            true => require_gte!(
+                pair.cash_reserve1,
+                amount_out,
+                ErrorCode::InsufficientCashReserve1
+            ),
+            false => require_gte!(
+                pair.cash_reserve0,
+                amount_out,
+                ErrorCode::InsufficientCashReserve0
+            ),
         }
 
         // Update reserves
@@ -217,7 +262,7 @@ impl<'info> Swap<'info> {
                 pair.reserve1 = new_reserve_out;
                 pair.cash_reserve0 = pair.cash_reserve0.saturating_add(amount_in_with_lp_fee);
                 pair.cash_reserve1 = pair.cash_reserve1.saturating_sub(amount_out);
-            },
+            }
             false => {
                 pair.reserve1 = new_reserve_in;
                 pair.reserve0 = new_reserve_out;
@@ -227,7 +272,13 @@ impl<'info> Swap<'info> {
         }
 
         // 2. x * y >= last_k
-        require_gte!((pair.reserve0 as u128).checked_mul(pair.reserve1 as u128).ok_or(ErrorCode::Overflow)?, last_k, ErrorCode::BrokenInvariant);
+        require_gte!(
+            (pair.reserve0 as u128)
+                .checked_mul(pair.reserve1 as u128)
+                .ok_or(ErrorCode::Overflow)?,
+            last_k,
+            ErrorCode::BrokenInvariant
+        );
 
         // Transfer tokens
         // First: Transfer user's input tokens into the vault
@@ -236,10 +287,11 @@ impl<'info> Swap<'info> {
             user_token_in_account.to_account_info(),
             token_in_vault.to_account_info(),
             token_in_mint.to_account_info(),
-            match token_in_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
+            token_program_for_mint(
+                &token_in_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
             amount_in,
             token_in_mint.decimals,
         )?;
@@ -250,15 +302,16 @@ impl<'info> Swap<'info> {
             token_out_vault.to_account_info(),
             user_token_out_account.to_account_info(),
             token_out_mint.to_account_info(),
-            match token_out_mint.to_account_info().owner == token_program.key {
-                true => token_program.to_account_info(),
-                false => token_2022_program.to_account_info(),
-            },
+            token_program_for_mint(
+                &token_out_mint.to_account_info(),
+                &token_program.to_account_info(),
+                &token_2022_program.to_account_info(),
+            )?,
             amount_out,
             token_out_mint.decimals,
             &[&generate_gamm_pair_seeds!(pair)[..]],
         )?;
-        
+
         let lp_fee = swap_fee.checked_sub(futarchy_fee).unwrap_or(0);
 
         emit_cpi!(SwapEvent {
@@ -267,12 +320,12 @@ impl<'info> Swap<'info> {
             reserve1: pair.reserve1,
             is_token0_in,
             amount_in: amount_in,
-            amount_out: amount_out,
+            amount_out: amount_out_user,
             amount_in_after_fee: amount_in_after_swap_fee as u64,
             lp_fee,
             protocol_fee: futarchy_fee,
         });
-        
+
         Ok(())
     }
 }

--- a/programs/omnipair/src/lib.rs
+++ b/programs/omnipair/src/lib.rs
@@ -161,6 +161,11 @@ pub mod omnipair {
         Liquidate::handle_liquidate(ctx)
     }
 
+    #[access_control(ctx.accounts.validate_transfer())]
+    pub fn transfer_user_position(ctx: Context<TransferUserPosition>) -> Result<()> {
+        TransferUserPosition::handle_transfer(ctx)
+    }
+
     // Flash loan instruction
     #[access_control(ctx.accounts.update_and_validate(&args))]
     pub fn flashloan<'info>(ctx: Context<'_, '_, '_, 'info, Flashloan<'info>>, args: FlashloanArgs) -> Result<()> {

--- a/programs/omnipair/src/state/user_position.rs
+++ b/programs/omnipair/src/state/user_position.rs
@@ -596,4 +596,66 @@ mod tests {
         assert_eq!(pair.cash_reserve0, 400);
         assert_eq!(pair.reserve0, 800);
     }
+
+    #[test]
+    fn liquidation_repayment_with_zero_cash_socializes_full_debt() {
+        let mut pair = test_pair();
+        let token0 = pair.token0;
+        pair.reserve0 = 1_000;
+        pair.cash_reserve0 = 100;
+        pair.total_debt0 = 500;
+        pair.total_debt0_shares = 500;
+
+        let mut user_position = test_position();
+        user_position.debt0_shares = 500;
+
+        user_position
+            .decrease_debt(
+                &mut pair,
+                &token0,
+                500,
+                DebtDecreaseReason::LiquidationRepayment {
+                    exact_shares: 500,
+                    cash_credit: 0,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(user_position.debt0_shares, 0);
+        assert_eq!(pair.total_debt0_shares, 0);
+        assert_eq!(pair.total_debt0, 0);
+        assert_eq!(pair.cash_reserve0, 100);
+        assert_eq!(pair.reserve0, 500);
+    }
+
+    #[test]
+    fn liquidation_repayment_with_zero_amount_clears_dust_shares() {
+        let mut pair = test_pair();
+        let token0 = pair.token0;
+        pair.reserve0 = 1_000;
+        pair.cash_reserve0 = 100;
+        pair.total_debt0 = 1;
+        pair.total_debt0_shares = DEBT_SHARE_SCALE as u128;
+
+        let mut user_position = test_position();
+        user_position.debt0_shares = 1;
+
+        user_position
+            .decrease_debt(
+                &mut pair,
+                &token0,
+                0,
+                DebtDecreaseReason::LiquidationRepayment {
+                    exact_shares: 1,
+                    cash_credit: 0,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(user_position.debt0_shares, 0);
+        assert_eq!(pair.total_debt0_shares, (DEBT_SHARE_SCALE - 1) as u128);
+        assert_eq!(pair.total_debt0, 1);
+        assert_eq!(pair.cash_reserve0, 100);
+        assert_eq!(pair.reserve0, 1_000);
+    }
 }

--- a/programs/omnipair/src/state/user_position.rs
+++ b/programs/omnipair/src/state/user_position.rs
@@ -55,50 +55,6 @@ impl UserPosition {
         self.owner != Pubkey::default() && self.pair != Pubkey::default()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.collateral0 == 0
-            && self.collateral1 == 0
-            && self.debt0_shares == 0
-            && self.debt1_shares == 0
-    }
-
-    pub fn clear(&mut self) {
-        let bump = self.bump;
-        self.owner = Pubkey::default();
-        self.pair = Pubkey::default();
-        self.collateral0_liquidation_cf_bps = 0;
-        self.collateral1_liquidation_cf_bps = 0;
-        self.collateral0 = 0;
-        self.collateral1 = 0;
-        self.debt0_shares = 0;
-        self.debt1_shares = 0;
-        self.bump = bump;
-    }
-
-    pub fn transfer_to(
-        &mut self,
-        recipient_position: &mut UserPosition,
-        recipient_owner: Pubkey,
-        pair: Pubkey,
-        recipient_bump: u8,
-    ) -> Result<()> {
-        require!(self.is_initialized(), ErrorCode::UserPositionNotInitialized);
-        require!(recipient_position.is_empty(), ErrorCode::RecipientPositionNotEmpty);
-
-        recipient_position.owner = recipient_owner;
-        recipient_position.pair = pair;
-        recipient_position.collateral0_liquidation_cf_bps = self.collateral0_liquidation_cf_bps;
-        recipient_position.collateral1_liquidation_cf_bps = self.collateral1_liquidation_cf_bps;
-        recipient_position.collateral0 = self.collateral0;
-        recipient_position.collateral1 = self.collateral1;
-        recipient_position.debt0_shares = self.debt0_shares;
-        recipient_position.debt1_shares = self.debt1_shares;
-        recipient_position.bump = recipient_bump;
-
-        self.clear();
-        Ok(())
-    }
-
     /// Set the fixed liquidation CF for a specific debt token.
     /// Called on borrow, remove_collateral, and liquidation to lock in the CF.
     pub fn set_liquidation_cf_for_debt_token(&mut self, debt_token: &Pubkey, pair: &Pair, liquidation_cf_bps: u16) {
@@ -512,58 +468,6 @@ mod tests {
         assert_eq!(pair.total_debt0, 0);
         assert_eq!(pair.cash_reserve0, 123);
         assert_eq!(user_position.debt0_shares, 0);
-    }
-
-    #[test]
-    fn transfer_to_moves_entire_position_and_clears_source() {
-        let pair = Pubkey::new_unique();
-        let recipient = Pubkey::new_unique();
-        let mut source = test_position();
-        source.owner = Pubkey::new_unique();
-        source.pair = pair;
-        source.collateral0_liquidation_cf_bps = 7_000;
-        source.collateral1_liquidation_cf_bps = 6_500;
-        source.collateral0 = 10;
-        source.collateral1 = 20;
-        source.debt0_shares = 30;
-        source.debt1_shares = 40;
-        source.bump = 9;
-        let mut destination = test_position();
-        destination.clear();
-
-        source.transfer_to(&mut destination, recipient, pair, 3).unwrap();
-
-        assert!(!source.is_initialized());
-        assert!(source.is_empty());
-        assert_eq!(source.bump, 9);
-        assert_eq!(destination.owner, recipient);
-        assert_eq!(destination.pair, pair);
-        assert_eq!(destination.collateral0_liquidation_cf_bps, 7_000);
-        assert_eq!(destination.collateral1_liquidation_cf_bps, 6_500);
-        assert_eq!(destination.collateral0, 10);
-        assert_eq!(destination.collateral1, 20);
-        assert_eq!(destination.debt0_shares, 30);
-        assert_eq!(destination.debt1_shares, 40);
-        assert_eq!(destination.bump, 3);
-    }
-
-    #[test]
-    fn transfer_to_rejects_non_empty_destination() {
-        let pair = Pubkey::new_unique();
-        let mut source = test_position();
-        source.owner = Pubkey::new_unique();
-        source.pair = pair;
-        source.collateral0 = 10;
-        let mut destination = test_position();
-        destination.clear();
-        destination.collateral1 = 1;
-
-        let err = source
-            .transfer_to(&mut destination, Pubkey::new_unique(), pair, 3)
-            .unwrap_err();
-
-        assert_eq!(err, error!(ErrorCode::RecipientPositionNotEmpty));
-        assert_eq!(source.collateral0, 10);
     }
 
     #[test]

--- a/programs/omnipair/src/state/user_position.rs
+++ b/programs/omnipair/src/state/user_position.rs
@@ -52,6 +52,50 @@ impl UserPosition {
         self.owner != Pubkey::default() && self.pair != Pubkey::default()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.collateral0 == 0
+            && self.collateral1 == 0
+            && self.debt0_shares == 0
+            && self.debt1_shares == 0
+    }
+
+    pub fn clear(&mut self) {
+        let bump = self.bump;
+        self.owner = Pubkey::default();
+        self.pair = Pubkey::default();
+        self.collateral0_liquidation_cf_bps = 0;
+        self.collateral1_liquidation_cf_bps = 0;
+        self.collateral0 = 0;
+        self.collateral1 = 0;
+        self.debt0_shares = 0;
+        self.debt1_shares = 0;
+        self.bump = bump;
+    }
+
+    pub fn transfer_to(
+        &mut self,
+        recipient_position: &mut UserPosition,
+        recipient_owner: Pubkey,
+        pair: Pubkey,
+        recipient_bump: u8,
+    ) -> Result<()> {
+        require!(self.is_initialized(), ErrorCode::UserPositionNotInitialized);
+        require!(recipient_position.is_empty(), ErrorCode::RecipientPositionNotEmpty);
+
+        recipient_position.owner = recipient_owner;
+        recipient_position.pair = pair;
+        recipient_position.collateral0_liquidation_cf_bps = self.collateral0_liquidation_cf_bps;
+        recipient_position.collateral1_liquidation_cf_bps = self.collateral1_liquidation_cf_bps;
+        recipient_position.collateral0 = self.collateral0;
+        recipient_position.collateral1 = self.collateral1;
+        recipient_position.debt0_shares = self.debt0_shares;
+        recipient_position.debt1_shares = self.debt1_shares;
+        recipient_position.bump = recipient_bump;
+
+        self.clear();
+        Ok(())
+    }
+
     /// Set the fixed liquidation CF for a specific debt token.
     /// Called on borrow, remove_collateral, and liquidation to lock in the CF.
     pub fn set_liquidation_cf_for_debt_token(&mut self, debt_token: &Pubkey, pair: &Pair, liquidation_cf_bps: u16) {
@@ -447,5 +491,57 @@ mod tests {
         assert_eq!(pair.total_debt0, 0);
         assert_eq!(pair.cash_reserve0, 123);
         assert_eq!(user_position.debt0_shares, 0);
+    }
+
+    #[test]
+    fn transfer_to_moves_entire_position_and_clears_source() {
+        let pair = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let mut source = test_position();
+        source.owner = Pubkey::new_unique();
+        source.pair = pair;
+        source.collateral0_liquidation_cf_bps = 7_000;
+        source.collateral1_liquidation_cf_bps = 6_500;
+        source.collateral0 = 10;
+        source.collateral1 = 20;
+        source.debt0_shares = 30;
+        source.debt1_shares = 40;
+        source.bump = 9;
+        let mut destination = test_position();
+        destination.clear();
+
+        source.transfer_to(&mut destination, recipient, pair, 3).unwrap();
+
+        assert!(!source.is_initialized());
+        assert!(source.is_empty());
+        assert_eq!(source.bump, 9);
+        assert_eq!(destination.owner, recipient);
+        assert_eq!(destination.pair, pair);
+        assert_eq!(destination.collateral0_liquidation_cf_bps, 7_000);
+        assert_eq!(destination.collateral1_liquidation_cf_bps, 6_500);
+        assert_eq!(destination.collateral0, 10);
+        assert_eq!(destination.collateral1, 20);
+        assert_eq!(destination.debt0_shares, 30);
+        assert_eq!(destination.debt1_shares, 40);
+        assert_eq!(destination.bump, 3);
+    }
+
+    #[test]
+    fn transfer_to_rejects_non_empty_destination() {
+        let pair = Pubkey::new_unique();
+        let mut source = test_position();
+        source.owner = Pubkey::new_unique();
+        source.pair = pair;
+        source.collateral0 = 10;
+        let mut destination = test_position();
+        destination.clear();
+        destination.collateral1 = 1;
+
+        let err = source
+            .transfer_to(&mut destination, Pubkey::new_unique(), pair, 3)
+            .unwrap_err();
+
+        assert_eq!(err, error!(ErrorCode::RecipientPositionNotEmpty));
+        assert_eq!(source.collateral0, 10);
     }
 }

--- a/programs/omnipair/src/state/user_position.rs
+++ b/programs/omnipair/src/state/user_position.rs
@@ -10,6 +10,9 @@ pub enum DebtDecreaseReason {
     Repayment,
     /// WriteOff: expects exact debt shares to be written off
     WriteOff(u128),
+    /// LiquidationRepayment: expects exact debt shares, credits actual cash repaid,
+    /// and socializes any uncovered debt reduction through virtual reserves.
+    LiquidationRepayment { exact_shares: u128, cash_credit: u64 },
 }
 
 #[account]
@@ -198,6 +201,7 @@ impl UserPosition {
             true => {
                 let shares = match reason {
                     DebtDecreaseReason::WriteOff(exact_shares) => exact_shares,
+                    DebtDecreaseReason::LiquidationRepayment { exact_shares, .. } => exact_shares,
                     DebtDecreaseReason::Repayment => (amount as u128)
                         .checked_mul(pair.total_debt0_shares)
                         .ok_or(ErrorCode::DebtShareMathOverflow)?
@@ -212,6 +216,14 @@ impl UserPosition {
                     DebtDecreaseReason::Repayment => pair.cash_reserve0 = pair.cash_reserve0.saturating_add(amount),
                     // r_virtual can't reach zero during write off
                     DebtDecreaseReason::WriteOff(_) => pair.reserve0 = pair.reserve0.checked_sub(amount).unwrap_or(1),
+                    DebtDecreaseReason::LiquidationRepayment { cash_credit, .. } => {
+                        let cash_credit = cash_credit.min(amount);
+                        pair.cash_reserve0 = pair.cash_reserve0.saturating_add(cash_credit);
+                        let socialized_loss = amount.saturating_sub(cash_credit);
+                        if socialized_loss > 0 {
+                            pair.reserve0 = pair.reserve0.checked_sub(socialized_loss).unwrap_or(1);
+                        }
+                    }
                 };
                 // Sync debt and shares: if shares reaches 0, reset debt to avoid orphaned state
                 if pair.total_debt0_shares == 0 && pair.total_debt0 > 0 {
@@ -221,6 +233,7 @@ impl UserPosition {
             false => {
                 let shares = match reason {
                     DebtDecreaseReason::WriteOff(exact_shares) => exact_shares,
+                    DebtDecreaseReason::LiquidationRepayment { exact_shares, .. } => exact_shares,
                     DebtDecreaseReason::Repayment => (amount as u128)
                         .checked_mul(pair.total_debt1_shares)
                         .ok_or(ErrorCode::DebtShareMathOverflow)?
@@ -233,6 +246,14 @@ impl UserPosition {
                 match reason {
                     DebtDecreaseReason::Repayment => pair.cash_reserve1 = pair.cash_reserve1.saturating_add(amount),
                     DebtDecreaseReason::WriteOff(_) => pair.reserve1 = pair.reserve1.checked_sub(amount).unwrap_or(1),
+                    DebtDecreaseReason::LiquidationRepayment { cash_credit, .. } => {
+                        let cash_credit = cash_credit.min(amount);
+                        pair.cash_reserve1 = pair.cash_reserve1.saturating_add(cash_credit);
+                        let socialized_loss = amount.saturating_sub(cash_credit);
+                        if socialized_loss > 0 {
+                            pair.reserve1 = pair.reserve1.checked_sub(socialized_loss).unwrap_or(1);
+                        }
+                    }
                 };
                 // Sync debt and shares: if shares reaches 0, reset debt to avoid orphaned state
                 if pair.total_debt1_shares == 0 && pair.total_debt1 > 0 {
@@ -543,5 +564,36 @@ mod tests {
 
         assert_eq!(err, error!(ErrorCode::RecipientPositionNotEmpty));
         assert_eq!(source.collateral0, 10);
+    }
+
+    #[test]
+    fn liquidation_repayment_credits_cash_and_socializes_shortfall() {
+        let mut pair = test_pair();
+        let token0 = pair.token0;
+        pair.reserve0 = 1_000;
+        pair.cash_reserve0 = 100;
+        pair.total_debt0 = 500;
+        pair.total_debt0_shares = 500;
+
+        let mut user_position = test_position();
+        user_position.debt0_shares = 500;
+
+        user_position
+            .decrease_debt(
+                &mut pair,
+                &token0,
+                500,
+                DebtDecreaseReason::LiquidationRepayment {
+                    exact_shares: 500,
+                    cash_credit: 300,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(user_position.debt0_shares, 0);
+        assert_eq!(pair.total_debt0_shares, 0);
+        assert_eq!(pair.total_debt0, 0);
+        assert_eq!(pair.cash_reserve0, 400);
+        assert_eq!(pair.reserve0, 800);
     }
 }

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -207,13 +207,9 @@ pub fn pessimistic_max_debt(
     }
 
     // V_impact: impact-aware collateral value using virtual reserves at the
-    // pessimistic directional/symmetric EMA price.
-    //
-    // This is intentionally stricter than liquidation's symmetric-EMA reference
-    // price. Borrowing and collateral removal are user-initiated risk increases,
-    // so they must not be able to front-run a stale high symmetric EMA after spot
-    // has already fallen. Liquidation stays on symmetric EMA to avoid giving an
-    // attacker a dump-spot-and-liquidate primitive.
+    // pessimistic directional/symmetric EMA price. This is stricter than
+    // liquidation's symmetric-EMA reference price by design: admission checks block
+    // stale-EMA borrowing/removal without making liquidations snap down to spot.
     let (collateral_ema_reserve, debt_ema_reserve) = construct_virtual_reserves_at_pessimistic_price(
         collateral_amm_reserve,
         debt_amm_reserve,
@@ -292,8 +288,7 @@ pub fn pessimistic_max_debt(
         / BPS_DENOMINATOR as u32) as u16;
 
     // Final borrow limit = V_impact * max_allowed_cf_bps / BPS.
-    // This is the pessimistic admission/control limit; it is expected to differ
-    // from liquidation's symmetric-EMA reference-price check.
+    // This is the pessimistic admission/control limit, not liquidation valuation.
     let final_borrow_limit: u64 = collateral_value_with_impact
         .saturating_mul(max_allowed_cf_bps as u128)
         .checked_div(BPS_DENOMINATOR_U128)

--- a/programs/omnipair/src/utils/gamm_math.rs
+++ b/programs/omnipair/src/utils/gamm_math.rs
@@ -206,11 +206,14 @@ pub fn pessimistic_max_debt(
         return Ok((0, 0, 0));
     }
 
-    // V_impact: impact-aware collateral value using virtual reserves at pessimistic price.
-    // This matches the valuation used in liquidation (CPCurve::calculate_amount_out),
-    // ensuring the borrow limit never exceeds the liquidation threshold.
-    // Without this, V_linear > V_impact for collateral > ~5.26% of AMM reserve,
-    // which would make max-borrow positions instantly liquidatable.
+    // V_impact: impact-aware collateral value using virtual reserves at the
+    // pessimistic directional/symmetric EMA price.
+    //
+    // This is intentionally stricter than liquidation's symmetric-EMA reference
+    // price. Borrowing and collateral removal are user-initiated risk increases,
+    // so they must not be able to front-run a stale high symmetric EMA after spot
+    // has already fallen. Liquidation stays on symmetric EMA to avoid giving an
+    // attacker a dump-spot-and-liquidate primitive.
     let (collateral_ema_reserve, debt_ema_reserve) = construct_virtual_reserves_at_pessimistic_price(
         collateral_amm_reserve,
         debt_amm_reserve,
@@ -288,9 +291,9 @@ pub fn pessimistic_max_debt(
         .saturating_mul((BPS_DENOMINATOR - LTV_BUFFER_BPS) as u32)
         / BPS_DENOMINATOR as u32) as u16;
 
-    // Final borrow limit = V_impact * max_allowed_cf_bps / BPS
-    // Uses impact-aware collateral value to match liquidation's valuation method,
-    // guaranteeing borrow_limit ≤ liquidation_limit for any collateral size.
+    // Final borrow limit = V_impact * max_allowed_cf_bps / BPS.
+    // This is the pessimistic admission/control limit; it is expected to differ
+    // from liquidation's symmetric-EMA reference-price check.
     let final_borrow_limit: u64 = collateral_value_with_impact
         .saturating_mul(max_allowed_cf_bps as u128)
         .checked_div(BPS_DENOMINATOR_U128)

--- a/programs/omnipair/src/utils/token.rs
+++ b/programs/omnipair/src/utils/token.rs
@@ -2,19 +2,20 @@
 /// https://github.com/raydium-io/raydium-cp-swap/blob/master/programs/cp-swap/src/utils/token.rs
 /// Handles token transfers and minting with support for old token program and spl_token_2022
 use crate::errors::ErrorCode;
-use anchor_lang::{prelude::*, system_program, solana_program::program::invoke};
+use anchor_lang::{prelude::*, solana_program::program::invoke, system_program};
 use anchor_spl::{
-    token::{self, Token, TokenAccount},
+    token::{self, Token, TokenAccount as SplTokenAccount},
     token_2022::{
         self,
-        Token2022,
         spl_token_2022::{
             self,
             extension::{
                 transfer_fee::{TransferFeeConfig, MAX_FEE_BASIS_POINTS},
+                transfer_hook::TransferHook,
                 ExtensionType, StateWithExtensions,
             },
         },
+        Token2022,
     },
     token_interface::{
         initialize_account3, spl_token_2022::extension::BaseStateWithExtensions,
@@ -32,14 +33,8 @@ pub fn sync_native_if_wsol<'a>(
 ) -> Result<()> {
     if *mint == spl_token::native_mint::id() {
         invoke(
-            &spl_token::instruction::sync_native(
-                token_program.key,
-                token_account.key,
-            )?,
-            &[
-                token_program.clone(),
-                token_account.clone(),
-            ],
+            &spl_token::instruction::sync_native(token_program.key, token_account.key)?,
+            &[token_program.clone(), token_account.clone()],
         )?;
     }
     Ok(())
@@ -59,6 +54,7 @@ pub fn transfer_from_user_to_vault<'a>(
     }
 
     if *token_program.key == Token2022::id() {
+        emit_token_2022_transfer_memo()?;
         token_2022::transfer_checked(
             CpiContext::new(
                 token_program.to_account_info(),
@@ -103,6 +99,7 @@ pub fn transfer_from_vault<'a>(
         return Ok(());
     }
     if *token_program.key == Token2022::id() {
+        emit_token_2022_transfer_memo()?;
         token_2022::transfer_checked(
             CpiContext::new_with_signer(
                 token_program.to_account_info(),
@@ -136,7 +133,7 @@ pub fn transfer_from_vault<'a>(
 }
 
 /// Transfers tokens from one vault account to another vault account.
-/// 
+///
 /// This function is an explicit alias for `transfer_from_vault`, providing clearer intent for vault-to-vault token movement.
 /// Arguments:
 ///   - `authority`: The account authorized to sign for the transfer (typically a PDA).
@@ -167,7 +164,7 @@ pub fn transfer_from_vault_to_vault<'a>(
 }
 
 /// Transfers tokens from one vault account to a user's token account.
-/// 
+///
 /// This function is an explicit alias for `transfer_from_vault`, providing clearer intent for vault-to-user token movement.
 /// Arguments:
 ///   - `authority`: The account authorized to sign for the transfer (typically a PDA).
@@ -200,6 +197,17 @@ pub fn transfer_from_vault_to_user<'a>(
         mint_decimals,
         signer_seeds,
     )
+}
+
+#[cfg(not(feature = "no-spl-memo"))]
+fn emit_token_2022_transfer_memo() -> Result<()> {
+    invoke(&spl_memo::build_memo(b"omnipair", &[]), &[])?;
+    Ok(())
+}
+
+#[cfg(feature = "no-spl-memo")]
+fn emit_token_2022_transfer_memo() -> Result<()> {
+    Ok(())
 }
 
 /// Issue a spl_token `MintTo` instruction.
@@ -259,7 +267,7 @@ pub fn get_transfer_inverse_fee(mint_info: &AccountInfo, post_fee_amount: u64) -
         return Ok(0);
     }
     if post_fee_amount == 0 {
-        return err!(ErrorCode::AmountZero);
+        return Ok(0);
     }
     let mint_data = mint_info.try_borrow_data()?;
     let mint = StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&mint_data)?;
@@ -273,12 +281,19 @@ pub fn get_transfer_inverse_fee(mint_info: &AccountInfo, post_fee_amount: u64) -
         } else {
             transfer_fee_config
                 .calculate_inverse_epoch_fee(epoch, post_fee_amount)
-                .unwrap()
+                .ok_or(ErrorCode::FeeMathOverflow)?
         }
     } else {
         0
     };
     Ok(fee)
+}
+
+pub fn amount_with_transfer_fee(mint_info: &AccountInfo, post_fee_amount: u64) -> Result<u64> {
+    let fee = get_transfer_inverse_fee(mint_info, post_fee_amount)?;
+    post_fee_amount
+        .checked_add(fee)
+        .ok_or(ErrorCode::FeeMathOverflow.into())
 }
 
 /// Calculate the fee for input amount
@@ -292,11 +307,32 @@ pub fn get_transfer_fee(mint_info: &AccountInfo, pre_fee_amount: u64) -> Result<
     let fee = if let Ok(transfer_fee_config) = mint.get_extension::<TransferFeeConfig>() {
         transfer_fee_config
             .calculate_epoch_fee(Clock::get()?.epoch, pre_fee_amount)
-            .unwrap()
+            .ok_or(ErrorCode::FeeMathOverflow)?
     } else {
         0
     };
     Ok(fee)
+}
+
+pub fn amount_after_transfer_fee(mint_info: &AccountInfo, pre_fee_amount: u64) -> Result<u64> {
+    let fee = get_transfer_fee(mint_info, pre_fee_amount)?;
+    pre_fee_amount
+        .checked_sub(fee)
+        .ok_or(ErrorCode::FeeMathOverflow.into())
+}
+
+pub fn token_program_for_mint<'a>(
+    mint_info: &AccountInfo<'a>,
+    token_program: &AccountInfo<'a>,
+    token_2022_program: &AccountInfo<'a>,
+) -> Result<AccountInfo<'a>> {
+    if mint_info.owner == token_program.key {
+        Ok(token_program.clone())
+    } else if mint_info.owner == token_2022_program.key {
+        Ok(token_2022_program.clone())
+    } else {
+        err!(ErrorCode::InvalidTokenProgram)
+    }
 }
 
 pub fn is_supported_mint(mint_account: &InterfaceAccount<Mint>) -> Result<bool> {
@@ -304,16 +340,28 @@ pub fn is_supported_mint(mint_account: &InterfaceAccount<Mint>) -> Result<bool> 
     if *mint_info.owner == Token::id() {
         return Ok(true);
     }
+    if spl_token_2022::native_mint::check_id(mint_info.key) {
+        return Ok(false);
+    }
 
     let mint_data = mint_info.try_borrow_data()?;
     let mint = StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&mint_data)?;
     let extensions = mint.get_extension_types()?;
     for e in extensions {
-        if e != ExtensionType::TransferFeeConfig
-            && e != ExtensionType::MetadataPointer
-            && e != ExtensionType::TokenMetadata
-        {
-            return Ok(false);
+        match e {
+            ExtensionType::TransferFeeConfig
+            | ExtensionType::MetadataPointer
+            | ExtensionType::TokenMetadata
+            | ExtensionType::InterestBearingConfig => {}
+            ExtensionType::TransferHook => {
+                let hook = mint.get_extension::<TransferHook>()?;
+                if Option::<Pubkey>::from(hook.program_id).is_some()
+                    || Option::<Pubkey>::from(hook.authority).is_some()
+                {
+                    return Ok(false);
+                }
+            }
+            _ => return Ok(false),
         }
     }
     Ok(true)
@@ -341,7 +389,7 @@ pub fn create_token_account<'a>(
                 &required_extensions,
             )?
         } else {
-            TokenAccount::LEN
+            SplTokenAccount::LEN
         }
     };
     create_or_allocate_account(

--- a/scripts/liquidate.ts
+++ b/scripts/liquidate.ts
@@ -23,6 +23,16 @@ dotenv.config();
 const TOKEN0_MINT = new PublicKey(process.env.TOKEN0_MINT || '');
 const TOKEN1_MINT = new PublicKey(process.env.TOKEN1_MINT || '');
 
+function paramsHashFromEnv(): Buffer {
+    const raw = process.env.PARAMS_HASH || '';
+    const hex = raw.startsWith('0x') ? raw.slice(2) : raw;
+    const bytes = Buffer.from(hex, 'hex');
+    if (bytes.length !== 32) {
+        throw new Error('Set PAIR_ADDRESS or PARAMS_HASH as a 32-byte hex string');
+    }
+    return bytes;
+}
+
 async function main() {
     console.log('Starting liquidation operation...');
     
@@ -49,10 +59,12 @@ async function main() {
     console.log('User address:', userPublicKey.toBase58());
 
     // Find PDA for the pair
-    const [pairPda] = PublicKey.findProgramAddressSync(
-        [Buffer.from('gamm_pair'), TOKEN0_MINT.toBuffer(), TOKEN1_MINT.toBuffer()],
-        program.programId
-    );
+    const pairPda = process.env.PAIR_ADDRESS
+        ? new PublicKey(process.env.PAIR_ADDRESS)
+        : PublicKey.findProgramAddressSync(
+            [Buffer.from('gamm_pair'), TOKEN0_MINT.toBuffer(), TOKEN1_MINT.toBuffer(), paramsHashFromEnv()],
+            program.programId
+        )[0];
 
     // Get pair account to get rate model
     const pairAccount = await program.account.pair.fetch(pairPda);
@@ -98,20 +110,21 @@ async function main() {
         ? TOKEN_2022_PROGRAM_ID 
         : TOKEN_PROGRAM_ID;
 
-    // Get associated token addresses for vaults
-    const token0Vault = await getAssociatedTokenAddress(
-        TOKEN0_MINT,
-        pairPda,
-        true,
-        token0Program,
-        ASSOCIATED_TOKEN_PROGRAM_ID
+    const [reserve0Vault] = PublicKey.findProgramAddressSync(
+        [Buffer.from('reserve_vault'), pairPda.toBuffer(), TOKEN0_MINT.toBuffer()],
+        program.programId
     );
-    const token1Vault = await getAssociatedTokenAddress(
-        TOKEN1_MINT,
-        pairPda,
-        true,
-        token1Program,
-        ASSOCIATED_TOKEN_PROGRAM_ID
+    const [reserve1Vault] = PublicKey.findProgramAddressSync(
+        [Buffer.from('reserve_vault'), pairPda.toBuffer(), TOKEN1_MINT.toBuffer()],
+        program.programId
+    );
+    const [collateral0Vault] = PublicKey.findProgramAddressSync(
+        [Buffer.from('collateral_vault'), pairPda.toBuffer(), TOKEN0_MINT.toBuffer()],
+        program.programId
+    );
+    const [collateral1Vault] = PublicKey.findProgramAddressSync(
+        [Buffer.from('collateral_vault'), pairPda.toBuffer(), TOKEN1_MINT.toBuffer()],
+        program.programId
     );
 
     // Liquidation parameters
@@ -120,9 +133,11 @@ async function main() {
     console.log('Liquidating with parameters:');
     console.log('Token:', liquidateToken0 ? 'Token0' : 'Token1');
 
-    // Get caller's token account for receiving liquidation incentive
+    // Get caller's token accounts for receiving seized collateral and repaying debt.
     const collateralMint = liquidateToken0 ? TOKEN0_MINT : TOKEN1_MINT;
+    const debtMint = liquidateToken0 ? TOKEN1_MINT : TOKEN0_MINT;
     const collateralTokenProgram = liquidateToken0 ? token0Program : token1Program;
+    const debtTokenProgram = liquidateToken0 ? token1Program : token0Program;
     const callerTokenAccount = await getAssociatedTokenAddress(
         collateralMint,
         DEPLOYER_KEYPAIR.publicKey,
@@ -130,7 +145,15 @@ async function main() {
         collateralTokenProgram,
         ASSOCIATED_TOKEN_PROGRAM_ID
     );
-    console.log('Caller token account (for incentive):', callerTokenAccount.toBase58());
+    const liquidatorDebtTokenAccount = await getAssociatedTokenAddress(
+        debtMint,
+        DEPLOYER_KEYPAIR.publicKey,
+        false,
+        debtTokenProgram,
+        ASSOCIATED_TOKEN_PROGRAM_ID
+    );
+    console.log('Caller token account (for seized collateral):', callerTokenAccount.toBase58());
+    console.log('Liquidator debt token account (for repayment):', liquidatorDebtTokenAccount.toBase58());
 
     // Create transaction
     const tx = await program.methods
@@ -142,9 +165,13 @@ async function main() {
             rateModel: RATE_MODEL,
             futarchyAuthority: futarchyAuthorityPda,
             userPosition: userPositionPda,
-            collateralVault: liquidateToken0 ? token0Vault : token1Vault,
+            collateralVault: liquidateToken0 ? collateral0Vault : collateral1Vault,
             callerTokenAccount: callerTokenAccount,
             collateralTokenMint: collateralMint,
+            debtTokenMint: debtMint,
+            debtReserveVault: liquidateToken0 ? reserve1Vault : reserve0Vault,
+            liquidatorDebtTokenAccount,
+            collateralReserveVault: liquidateToken0 ? reserve0Vault : reserve1Vault,
             tokenProgram: TOKEN_PROGRAM_ID,
             token2022Program: TOKEN_2022_PROGRAM_ID,
             systemProgram: SystemProgram.programId,
@@ -156,4 +183,4 @@ async function main() {
     console.log('Signature:', tx);
 }
 
-main().catch(console.error); 
+main().catch(console.error);


### PR DESCRIPTION
## Summary

- Merges the draft V1 branches from #91, #93, and #94 into one PR.
- Replaces V1 liquidation settlement with an EMA reference-price repay-and-seize model: liquidators repay debt tokens into the debt reserve vault, receive repaid-value collateral plus the liquidation incentive, and the remaining penalty collateral goes to reserves.
- Keeps insolvent liquidation cleanup, but now socializes only the uncovered debt after collateral is exhausted and real repayment cash is credited.
- Keeps the 1% liquidity withdrawal fee removed, while restoring the 115% post-withdraw debt coverage buffer.
- Adds a consent-based `transfer_user_position` instruction that moves the full borrow/collateral position to the recipient PDA and clears the source position. Both current owner and recipient must sign.
- Updates Carbon decoder coverage and the liquidation helper script for the new account list.

## Merged PRs

- #91: OMFG-986 Add swap event in liquidation ixn
- #93: Reduce withdrawal debt coverage to 100%
- #94: fix liquidation underflow on insolvent positions

## Validation

Passed:

- `anchor build --program-name omnipair`
- `npm run build --prefix packages/program-interface`
- `cargo check -p omnipair --lib`
- `cargo check -p omnipair-decoder --features serde`
- `cargo test -p omnipair --lib instructions::lending::liquidate::tests`
- `cargo test -p omnipair --lib state::user_position::tests::liquidation_repayment_credits_cash_and_socializes_shortfall`
- `cargo test -p omnipair --lib transfer_to`
- `cargo test -p omnipair --lib liquidity_delta_withdrawal_solvency`

Known existing failures observed:

- `cargo test -p omnipair --lib` compiles, but fails existing rate-model / GAMM math tests: `test_uncapped_rate_grows_exponentially`, `test_faster_half_life_adjusts_quicker`, `test_default_matches_original_high_util`, `test_default_matches_original_low_util`, and `manipulation_bounded_by_ema`.
- Root `cargo fmt` is blocked by existing workspace issues around the generated decoder `graphql` module and trailing whitespace in old files.
