### PR TITLE
fix: derive rate_model as a PDA so multisigs can deploy markets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "omnipair"
-version = "0.9.9"
+version = "0.10.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/audits/ackee/trident-tests/fuzz/liquidity/init_pair.rs
+++ b/audits/ackee/trident-tests/fuzz/liquidity/init_pair.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     utils::{
         EVENT_AUTHORITY_ADDRESS, METADATA_SEED_PREFIX,
-        MPL_TOKEN_METADATA_ID, PAIR_SEED_PREFIX, TOKEN_PROGRAM,
+        MPL_TOKEN_METADATA_ID, PAIR_SEED_PREFIX, RATE_MODEL_SEED_PREFIX, TOKEN_PROGRAM,
     },
     FuzzTest,
 };
@@ -185,8 +185,14 @@ impl FuzzTest {
         // futarchy authority PDA
         let futarchy_authority = self.fuzz_accounts.futarchy_authority.get(&mut self.trident).expect("Futarchy authority should exist");
 
-        // rate model
-        let rate_model = self.trident.random_keypair().pubkey();
+        // rate model PDA, derived from the pair
+        let rate_model = self
+            .trident
+            .find_program_address(
+                &[RATE_MODEL_SEED_PREFIX, pair.as_ref()],
+                &omnipair::program_id(),
+            )
+            .0;
 
         // lp mint
 

--- a/audits/ackee/trident-tests/fuzz/types.rs
+++ b/audits/ackee/trident-tests/fuzz/types.rs
@@ -1929,7 +1929,7 @@ pub mod omnipair {
             self.accounts.futarchy_authority =
                 AccountMeta::new_readonly(accounts.futarchy_authority, false);
 
-            self.accounts.rate_model = AccountMeta::new(accounts.rate_model, true);
+            self.accounts.rate_model = AccountMeta::new(accounts.rate_model, false);
 
             self.accounts.lp_mint = AccountMeta::new(accounts.lp_mint, false);
 

--- a/audits/ackee/trident-tests/fuzz/utils.rs
+++ b/audits/ackee/trident-tests/fuzz/utils.rs
@@ -17,6 +17,7 @@ pub const WSOL_MINT_ADDRESS: Pubkey = pubkey!("So1111111111111111111111111111111
 pub const FUTARCHY_AUTHORITY_SEED_PREFIX: &[u8] = b"futarchy_authority";
 pub const METADATA_SEED_PREFIX: &[u8] = b"metadata";
 pub const PAIR_SEED_PREFIX: &[u8] = b"gamm_pair";
+pub const RATE_MODEL_SEED_PREFIX: &[u8] = b"rate_model";
 pub const LP_MINT_SEED_PREFIX: &[u8] = b"gamm_lp_mint";
 pub const POSITION_SEED_PREFIX: &[u8] = b"gamm_position";
 

--- a/audits/ackee/trident-tests/fuzz_lending/liquidity/init_pair.rs
+++ b/audits/ackee/trident-tests/fuzz_lending/liquidity/init_pair.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     utils::{
         EVENT_AUTHORITY_ADDRESS, METADATA_SEED_PREFIX,
-        MPL_TOKEN_METADATA_ID, PAIR_SEED_PREFIX, TOKEN_PROGRAM,
+        MPL_TOKEN_METADATA_ID, PAIR_SEED_PREFIX, RATE_MODEL_SEED_PREFIX, TOKEN_PROGRAM,
     },
     FuzzTest,
 };
@@ -185,8 +185,14 @@ impl FuzzTest {
         // futarchy authority PDA
         let futarchy_authority = self.fuzz_accounts.futarchy_authority.get(&mut self.trident).expect("Futarchy authority should exist");
 
-        // rate model
-        let rate_model = self.trident.random_keypair().pubkey();
+        // rate model PDA, derived from the pair
+        let rate_model = self
+            .trident
+            .find_program_address(
+                &[RATE_MODEL_SEED_PREFIX, pair.as_ref()],
+                &omnipair::program_id(),
+            )
+            .0;
 
         // lp mint
 

--- a/audits/ackee/trident-tests/fuzz_lending/types.rs
+++ b/audits/ackee/trident-tests/fuzz_lending/types.rs
@@ -1929,7 +1929,7 @@ pub mod omnipair {
             self.accounts.futarchy_authority =
                 AccountMeta::new_readonly(accounts.futarchy_authority, false);
 
-            self.accounts.rate_model = AccountMeta::new(accounts.rate_model, true);
+            self.accounts.rate_model = AccountMeta::new(accounts.rate_model, false);
 
             self.accounts.lp_mint = AccountMeta::new(accounts.lp_mint, false);
 

--- a/audits/ackee/trident-tests/fuzz_lending/utils.rs
+++ b/audits/ackee/trident-tests/fuzz_lending/utils.rs
@@ -17,6 +17,7 @@ pub const WSOL_MINT_ADDRESS: Pubkey = pubkey!("So1111111111111111111111111111111
 pub const FUTARCHY_AUTHORITY_SEED_PREFIX: &[u8] = b"futarchy_authority";
 pub const METADATA_SEED_PREFIX: &[u8] = b"metadata";
 pub const PAIR_SEED_PREFIX: &[u8] = b"gamm_pair";
+pub const RATE_MODEL_SEED_PREFIX: &[u8] = b"rate_model";
 pub const LP_MINT_SEED_PREFIX: &[u8] = b"gamm_lp_mint";
 pub const POSITION_SEED_PREFIX: &[u8] = b"gamm_position";
 

--- a/audits/ackee/trident-tests/fuzz_liquidity_swaps/liquidity/init_pair.rs
+++ b/audits/ackee/trident-tests/fuzz_liquidity_swaps/liquidity/init_pair.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     utils::{
         EVENT_AUTHORITY_ADDRESS, METADATA_SEED_PREFIX,
-        MPL_TOKEN_METADATA_ID, PAIR_SEED_PREFIX, TOKEN_PROGRAM,
+        MPL_TOKEN_METADATA_ID, PAIR_SEED_PREFIX, RATE_MODEL_SEED_PREFIX, TOKEN_PROGRAM,
     },
     FuzzTest,
 };
@@ -185,8 +185,14 @@ impl FuzzTest {
         // futarchy authority PDA
         let futarchy_authority = self.fuzz_accounts.futarchy_authority.get(&mut self.trident).expect("Futarchy authority should exist");
 
-        // rate model
-        let rate_model = self.trident.random_keypair().pubkey();
+        // rate model PDA, derived from the pair
+        let rate_model = self
+            .trident
+            .find_program_address(
+                &[RATE_MODEL_SEED_PREFIX, pair.as_ref()],
+                &omnipair::program_id(),
+            )
+            .0;
 
         // lp mint
 

--- a/audits/ackee/trident-tests/fuzz_liquidity_swaps/types.rs
+++ b/audits/ackee/trident-tests/fuzz_liquidity_swaps/types.rs
@@ -1929,7 +1929,7 @@ pub mod omnipair {
             self.accounts.futarchy_authority =
                 AccountMeta::new_readonly(accounts.futarchy_authority, false);
 
-            self.accounts.rate_model = AccountMeta::new(accounts.rate_model, true);
+            self.accounts.rate_model = AccountMeta::new(accounts.rate_model, false);
 
             self.accounts.lp_mint = AccountMeta::new(accounts.lp_mint, false);
 

--- a/audits/ackee/trident-tests/fuzz_liquidity_swaps/utils.rs
+++ b/audits/ackee/trident-tests/fuzz_liquidity_swaps/utils.rs
@@ -16,6 +16,7 @@ pub const WSOL_MINT_ADDRESS: Pubkey = pubkey!("So1111111111111111111111111111111
 pub const FUTARCHY_AUTHORITY_SEED_PREFIX: &[u8] = b"futarchy_authority";
 pub const METADATA_SEED_PREFIX: &[u8] = b"metadata";
 pub const PAIR_SEED_PREFIX: &[u8] = b"gamm_pair";
+pub const RATE_MODEL_SEED_PREFIX: &[u8] = b"rate_model";
 pub const POSITION_SEED_PREFIX: &[u8] = b"gamm_position";
 
 // EVENT AUTHORITY

--- a/programs/omnipair/src/constants.rs
+++ b/programs/omnipair/src/constants.rs
@@ -108,6 +108,8 @@ pub const RESERVE_VAULT_SEED_PREFIX: &[u8] = b"reserve_vault";
 #[constant]
 pub const COLLATERAL_VAULT_SEED_PREFIX: &[u8] = b"collateral_vault";
 #[constant]
+pub const RATE_MODEL_SEED_PREFIX: &[u8] = b"rate_model";
+#[constant]
 pub const VERSION: u8 = 1;
 
 /// Emergency signer authorized to toggle reduce-only mode.

--- a/programs/omnipair/src/instructions/liquidity/initialize.rs
+++ b/programs/omnipair/src/instructions/liquidity/initialize.rs
@@ -91,10 +91,25 @@ pub struct InitializeAndBootstrap<'info> {
     )]
     pub futarchy_authority: Account<'info, FutarchyAuthority>,
 
+    /// Derived from the pair rather than passed as a fresh keypair, so creating
+    /// a market needs no signature beyond the deployer's. A keypair signer made
+    /// deployment impossible for a multisig, whose vault cannot produce one.
+    ///
+    /// Deliberately not seeded on the rate parameters: one pair owns one rate
+    /// model, which avoids `init_if_needed` and any chance of overwriting a
+    /// model another pair is already using. Sharing a model across pairs is
+    /// still available through `create_rate_model` + `set_pair_rate_model`.
+    ///
+    /// The bump is recomputed rather than stored: adding a field would change
+    /// `RateModel`'s size and break every account created before this change.
+    /// No other instruction validates this account by seeds, so it is only
+    /// needed here.
     #[account(
         init,
         payer = deployer,
         space = get_size_with_discriminator::<RateModel>(),
+        seeds = [RATE_MODEL_SEED_PREFIX, pair.key().as_ref()],
+        bump,
     )]
     pub rate_model: Box<Account<'info, RateModel>>,
 


### PR DESCRIPTION
## Problem

`initialize` took `rate_model` as a fresh keypair account:

```rust
#[account(init, payer = deployer, space = get_size_with_discriminator::<RateModel>())]
pub rate_model: Box<Account<'info, RateModel>>,
```

That makes market creation require a second signature. A multisig vault cannot produce one, so deploying a market from a multisig was impossible regardless of what the frontend did: the wrapped transaction ends up requiring a signature from an ephemeral keypair that only ever existed in the deployer's browser, and fails at execution.

Every other flow works through a multisig because each needs only one signer, the vault. Market creation was the sole exception.

## Change

`RATE_MODEL_SEED_PREFIX` in constants, and seeds on the account:

```rust
seeds = [RATE_MODEL_SEED_PREFIX, pair.key().as_ref()],
bump,
```

IDL before and after:

```
before:  signer: true   pda: NONE
after:   signer: false  pda: ["rate_model", pair]
         signers on initialize: deployer
```

## Why this is not a breaking change

Every instruction that consumes a rate model validates it by stored address, never by derivation:

```rust
#[account(mut, address = pair.rate_model)]
pub rate_model: Account<'info, RateModel>,
```

That is all 11 of them: `swap`, `borrow`, `repay`, `add_collateral`, `remove_collateral`, `flashloan`, `liquidate`, `remove_liquidity`, `claim_protocol_fees`, and both `emit_value` variants. A repo-wide search for seed-based rate-model derivation returns zero hits.

Existing pairs keep pointing at their current keypair accounts and nothing revalidates them. Only newly created markets get a PDA.

Two deliberate choices:

- **Seeded on the pair, not on the rate parameters.** One pair owns one rate model, which avoids `init_if_needed` and any chance of overwriting a model another pair is already using. Sharing across pairs is still available through `create_rate_model` plus `set_pair_rate_model`, both untouched.
- **The bump is recomputed, not stored.** `RateModel` is 7 x u64. Adding a `bump` field would change its size and break deserialization for every account created before this change. No other instruction validates by seeds, so the bump is only needed in `initialize`.

## Fuzz harnesses

The Trident harnesses passed `random_keypair().pubkey()` as `rate_model`, which no longer matches the derived address, and separately built the instruction with `AccountMeta::new(rate_model, true)`, preserving a signature requirement a PDA cannot satisfy. Trident mocks signature pre-checks, so this passed while misrepresenting the instruction. Both are fixed, and the seed prefix is added to each harness's `utils.rs`.

## Verification

Tested against a mainnet fork with this build deployed over real state.

- Every existing pair on the fork carries a legacy keypair rate model, and all of them still load and execute under the new program
- Account layout is unchanged at 64 bytes, legacy and new, which is what makes that work
- `swap`, `add_liquidity`, `add_collateral`, `borrow`, `repay`, `remove_collateral` and `remove_liquidity` all succeed against a legacy market
- `liquidate` reaches its health check and is rejected on business logic, which proves the legacy rate model loaded and passed `address = pair.rate_model`, since Anchor validates in declaration order and `rate_model` precedes the vaults
- Creating a new market requires one signature instead of two, and `pair.rate_model` matches the derived PDA

Also: `cargo check -p omnipair` and the Trident harnesses compile; IDL regenerated with `anchor idl build`.

The TypeScript suite does not cover this change. `basic.test.ts` and `futarchy.test.ts` assert futarchy PDA math, IDL parsing, LiteSVM connectivity and an airdrop; nothing calls `initialize`.

Note for anyone testing: `Anchor.toml` sets `cluster = "mainnet"`, so a bare `anchor test` targets mainnet rather than a local validator. Override the provider before running it.

## Sequencing

The frontend change that derives the PDA instead of generating a keypair must land only after this is deployed, since the live program still requires the signer.